### PR TITLE
Add x402 APIs for founder insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Projects building with or extending x402.
 - [Zyte.com](https://www.zyte.com) - Web scraping with x402 payments.
 - [BuffetPay](https://buffetpay.com) - Smart x402 payments with guardrails.
 - [Cal.com](https://cal.com) - Automated scheduling with payments.
+- [AIAgentStore.ai](https://aiagentstore.ai/developer) - Insights for founders with x402 payments.
 
 ### DeFi & Finance
 


### PR DESCRIPTION
Add AIAgentStore micro‑pay APIs: pay‑per‑answer endpoints using x402. Useful for founders looking to validate product ideas, find out demand from real data, etc.