### PR TITLE
Add PolicyLayer - spending controls for x402 payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,10 @@ Security resources and best practices for x402 implementations.
 
 - [Rate Limiting Tools](https://docs.cdp.coinbase.com/x402/security/rate-limiting) - Prevent abuse and ensure service availability.
 
+### Spending Controls & Policy Enforcement
+
+- [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. As AI agents increasingly need to make on-chain payments (buying APIs, paying for services, executing trades), they need financial guardrails. PolicyLayer enforces daily spending limits, per-transaction caps, recipient whitelists, and rate limiting — all without holding private keys. Prevents wallet drains from bugs, prompt injection attacks, or infinite loops. [GitHub](https://github.com/PolicyLayer/PolicyLayer) | [npm](https://www.npmjs.com/package/@policylayer/sdk)
+
 ## 🔗 Related Protocols
 
 Adjacent protocols and standards.


### PR DESCRIPTION
Hi! I'd like to add PolicyLayer to the awesome-x402 list.

## What is PolicyLayer?

PolicyLayer is a non-custodial policy enforcement layer for x402 payments. It lets developers set spending limits, recipient allowlists, and rate limits on x402 transactions without custodying private keys.

## Why it belongs here

- **Built specifically for x402**: Native integration with the x402 protocol
- **Addresses a real need**: As autonomous agents make more payments, spending controls become critical
- **Non-custodial**: Keys never leave the developer's infrastructure
- **Works with existing x402 implementations**: Compatible with Coinbase and Cloudflare facilitators

## Placement

Added under "Security & Audits" → "Spending Controls & Policy Enforcement" as a new subsection, since this is specifically about securing x402 payment flows.

Happy to adjust the placement or description if you have preferences!