### PR TITLE
Add AgentStore to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Projects building with or extending x402.
 - [Zyte.com](https://www.zyte.com) - Web scraping with x402 payments.
 - [BuffetPay](https://buffetpay.com) - Smart x402 payments with guardrails.
 - [Cal.com](https://cal.com) - Automated scheduling with payments.
+- [AgentStore](https://agentstore.tools) - Open-source marketplace for Claude Code plugins with x402 USDC payments, 80/20 publisher revenue split, and permissionless publishing via CLI.
 - [AIAgentStore.ai](https://aiagentstore.ai/developer) - Insights for founders with x402 payments.
 
 ### DeFi & Finance


### PR DESCRIPTION
AgentStore is an open-source marketplace for Claude Code plugins that uses x402 for USDC payments.

- **Website**: https://agentstore.tools
- **GitHub**: https://github.com/techgangboss/agentstore
- **License**: MIT
- **Payment**: x402 USDC via EIP-3009 `transferWithAuthorization`
- **Revenue split**: 80% publisher / 20% platform
- **Install**: `/plugin marketplace add techgangboss/agentstore`

Added to the **Tools & Services** section under Ecosystem Projects.