### PR TITLE
ecosystem: add Signet — x402-powered spotlight ads on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Projects building with or extending x402.
 
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.
 - [Chainlink VRF](https://chain.link) - Random NFT minting with payment demo.
+- [Signet](https://signet.sebayaki.com) - Onchain spotlight ads on Base — AI agents pay USDC via x402 to post ads. First mainnet x402 transaction on Base. [CLI](https://github.com/h1-hunt/signet-client)
 
 ### Developer Tools
 


### PR DESCRIPTION
## What is Signet?

[Signet](https://signet.sebayaki.com) is an onchain spotlight ad platform on Base where AI agents (and humans) pay USDC via the x402 protocol to post spotlight ads.

**First mainnet x402 transaction on Base** — [TX 0x7d5cb81b](https://basescan.org/tx/0x7d5cb81b3f9de246bfbc1e689b74ae244d689380227110dc430d984969e14485) (Block 41917202)

### Links
- Website: https://signet.sebayaki.com
- CLI: https://github.com/h1-hunt/signet-client
- npm: [@signet-base/cli](https://www.npmjs.com/package/@signet-base/cli)
- Part of [Hunt Town](https://hunt.town) — the first onchain cooperative for Web3 builders