### PR TITLE
Add CrossFin — Korean Market Data APIs for x402 Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Projects building with or extending x402.
 
 ### Tools & Services
 
+- [CrossFin](https://crossfin.dev) — x402 Agent Services Gateway with 15 paid Korean market data APIs (Kimchi Premium, KOSPI, Bithumb, Upbit, Coinone, FX, headlines, trading signals). First financial data APIs in the x402 ecosystem. MCP server included.
 - [x402 API Network](https://x402.fatihai.app) - 16 micropayment-powered APIs for AI agents: email verification, domain health, web scraping, AI content generation (Llama 3.3 70B), DNS, WHOIS, SSL check, and more. Includes MCP server, Bazaar discovery, and .well-known/x402 manifest. ([GitHub](https://github.com/fatihdagustu20-hub/x402-api-network))
 - [dTelecom STT](https://x402stt.dtelecom.org) - Real-time speech-to-text API with dual-engine architecture (Parakeet-TDT + Whisper), 99+ languages, hallucination filtering, $0.005/min. Built on dTelecom DePIN. [Python SDK](https://github.com/dTelecom/stt-client-python) | [TypeScript SDK](https://github.com/dTelecom/stt-client-ts)
 - [BlockRun](https://blockrun.ai) - AI Gateway + Service Directory with 600+ x402 services indexed, trust scores, and 31+ AI models via pay-per-use USDC.


### PR DESCRIPTION
CrossFin provides 15+ paid Korean financial market APIs via x402 on Base mainnet. Includes real-time kimchi premium index, Korean stock market (KOSPI/KOSDAQ), cross-exchange arbitrage signals, and an MCP server for Claude Desktop integration. Live at https://crossfin.dev