### PR TITLE
Add Apollo Intelligence Network (27 x402 endpoints, 26-tool MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Enable AI agents to make autonomous payments.
 - x402 MCP Server - Claude Desktop ready server.
 - [MCP Server Setup Guide](https://docs.cdp.coinbase.com/x402/mcp-server) - Complete installation instructions.
 - Embedded Wallet MCP - Electron-based wallet for MCP.
+- [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
 
 ### Agent Frameworks
 
@@ -452,6 +453,7 @@ Projects building with or extending x402.
 - [AgentStore](https://agentstore.tools) - Open-source marketplace for Claude Code plugins with x402 USDC payments, 80/20 publisher revenue split, and permissionless publishing via CLI.
 - [AIAgentStore.ai](https://aiagentstore.ai/developer) - Insights for founders with x402 payments.
 - [Einstein AI](https://emc2ai.io) - AI blockchain intelligence with 23 x402 endpoints. Whale tracking, smart money, launchpad monitoring, security audits.
+- [Apollo Intelligence Network](https://apolloai.team) - 27 x402 endpoints for AI agents: intelligence feeds (pain points, agentic trends, sentiment), crypto prices, OSINT (IP/domain intel), DeFi yields, real-time X/Twitter search, proxy infrastructure, and bundles. MCP server with 26 tools. USDC on Base. ([GitHub](https://github.com/bnmbnmai/mcp-proxy)) | ([npm](https://www.npmjs.com/package/@apollo_ai/mcp-proxy))
 - [OpSpawn Screenshot API](https://github.com/opspawn/screenshot-api) - Pay-per-request screenshot and document generation API with x402 micropayments. $0.01/screenshot, $0.005/markdown conversion. USDC on Base.
 
 ### DeFi & Finance


### PR DESCRIPTION
## Apollo Intelligence Network

**Website:** https://apolloai.team
**GitHub:** https://github.com/bnmbnmai/mcp-proxy
**npm:** https://www.npmjs.com/package/@apollo_ai/mcp-proxy

### What is Apollo?

Apollo Intelligence Network provides **27 x402-gated endpoints** for AI agents, covering:

- **Intelligence feeds**: Pain points, agentic trends, sentiment analysis, agent economy opportunities
- **Crypto data**: Live prices, trending coins (CoinGecko)
- **OSINT**: IP intelligence (Shodan/GreyNoise/OTX), domain intelligence (DNS/SSL/threats)
- **DeFi**: Yield rankings (18K+ pools), protocol TVL data (7K+ protocols)
- **Real-time search**: X/Twitter via Grok, web search, GitHub trending, Product Hunt launches
- **Proxy infrastructure**: Residential proxy relay (190+ countries), dedicated IP sessions
- **Bundles**: Opportunity Pack, Agentic Insights, Builder Intel (discounted multi-feed)

All endpoints accept USDC on Base mainnet via x402.

### MCP Server

26-tool MCP server published on npm: `npx @apollo_ai/mcp-proxy`

Works with Claude Desktop, Cursor, and any MCP-compatible client.

### Changes

- Added Apollo Intelligence Network to **Tools & Services** in Ecosystem Projects
- Added Apollo MCP Server to **Model Context Protocol (MCP)** section