### PR TITLE
Add MaximumSats MCP to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Enable AI agents to make autonomous payments.
 - x402 MCP Server - Claude Desktop ready server.
 - [MCP Server Setup Guide](https://docs.cdp.coinbase.com/x402/mcp-server) - Complete installation instructions.
 - Embedded Wallet MCP - Electron-based wallet for MCP.
+- [MaximumSats MCP](https://github.com/joelklabo/maximumsats-mcp) - Lightning-native MCP tools with L402 micropayments and Nostr Web-of-Trust scoring APIs.
 - [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
 
 ### Agent Frameworks


### PR DESCRIPTION
## Summary\n- add MaximumSats MCP under the Model Context Protocol (MCP) section\n- describe it as a Lightning-native MCP server with L402 micropayments and Nostr Web-of-Trust scoring APIs\n\n## Why\n- this is a production MCP integration relevant to x402-adjacent agent payment workflows\n- gives builders another concrete MCP option for paid agent tools\n\n## Testing\n- docs-only change