### PR TITLE
Add Pylon — x402 utility API gateway + MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Enable AI agents to make autonomous payments.
 - Embedded Wallet MCP - Electron-based wallet for MCP.
 - [MaximumSats MCP](https://github.com/joelklabo/maximumsats-mcp) - Lightning-native MCP tools with L402 micropayments and Nostr Web-of-Trust scoring APIs.
 - [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
+- [Pylon MCP Server](https://www.npmjs.com/package/@pylonapi/mcp) - 20-tool MCP server for utility APIs: web extraction, search, translation, code execution, image generation, email, and more. `npx @pylonapi/mcp`. ([GitHub](https://github.com/pylon-apis/pylon-mcp))
 
 ### Agent Frameworks
 
@@ -450,6 +451,7 @@ Projects building with or extending x402.
 
 ### Tools & Services
 
+- [Pylon](https://pylonapi.com) — x402-payable utility API gateway for AI agents. 20 capabilities (web extraction, search, translation, code execution, image generation, and more) on Base mainnet. MCP server (`npx @pylonapi/mcp`), agent reputation network, and gateway orchestration. USDC on Base. ([GitHub](https://github.com/pylon-apis/pylon-mcp))
 - [CrossFin](https://crossfin.dev) — x402 Agent Services Gateway with 15 paid Korean market data APIs (Kimchi Premium, KOSPI, Bithumb, Upbit, Coinone, FX, headlines, trading signals). First financial data APIs in the x402 ecosystem. MCP server included.
 - [x402 API Network](https://x402.fatihai.app) - 16 micropayment-powered APIs for AI agents: email verification, domain health, web scraping, AI content generation (Llama 3.3 70B), DNS, WHOIS, SSL check, and more. Includes MCP server, Bazaar discovery, and .well-known/x402 manifest. ([GitHub](https://github.com/fatihdagustu20-hub/x402-api-network))
 - [dTelecom STT](https://x402stt.dtelecom.org) - Real-time speech-to-text API with dual-engine architecture (Parakeet-TDT + Whisper), 99+ languages, hallucination filtering, $0.005/min. Built on dTelecom DePIN. [Python SDK](https://github.com/dTelecom/stt-client-python) | [TypeScript SDK](https://github.com/dTelecom/stt-client-ts)


### PR DESCRIPTION
Adds [Pylon](https://pylonapi.com) to the ecosystem:

**Tools & Services:** x402-payable utility API gateway with 20 capabilities (web extraction, search, translation, code execution, image generation, etc.) on Base mainnet. Includes MCP server, agent reputation network, and gateway orchestration.

**MCP Section:** Pylon MCP Server (`npx @pylonapi/mcp`) — 20-tool MCP server for utility APIs.

- **Website:** https://pylonapi.com
- **GitHub:** https://github.com/pylon-apis/pylon-mcp
- **npm:** @pylonapi/mcp
- **Payments:** USDC on Base mainnet via x402