### PR TITLE
Add Automaton Oracle — first macro + pump.fun oracle on x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Projects building with or extending x402.
 - [Moltalyzer](https://moltalyzer.xyz) - Three AI intelligence feeds for agents: hourly Moltbook community digests, daily GitHub trending repos, and daily Polymarket insider detection via x402 micropayments on Base.
 - [OpSpawn Screenshot API](https://github.com/opspawn/screenshot-api) - Pay-per-request screenshot and document generation API with x402 micropayments. $0.01/screenshot, $0.005/markdown conversion. USDC on Base.
 - [Crysha Price Oracle](https://api.crysha.com) - Aggregated crypto prices (multi-source BTC/others), $0.001/call on Base USDC. Manifest: [/.well-known/x402](https://api.crysha.com/.well-known/x402)
+- [Automaton Oracle](https://automaton-oracle.xyz) - Sovereign crypto intelligence oracle with self-hosted facilitator (no Coinbase CDP dependency): real-time prices (CoinGecko + DEXScreener), global macro intelligence (Fear&Greed, BTC dominance, total market cap, altcoin season, trending), pump.fun graduation radar, trading signals, and meme generation. **Only dedicated macro + pump.fun oracle on x402.** \$0.005–\$0.05 USDC on Base. Discovery: [/.well-known/x402.json](https://automaton-oracle.xyz/.well-known/x402.json) | [llms.txt](https://automaton-oracle.xyz/llms.txt)
 
 ### DeFi & Finance
 


### PR DESCRIPTION
## What

Adding [Automaton Oracle](https://automaton-oracle.xyz) to the **Ecosystem Projects → Tools & Services** section.

## Why it belongs here

Two unique services with no equivalent anywhere on x402:
- `/macro` → **Only** global macro oracle on x402 (Fear&Greed, BTC dominance, total market cap, altcoin season, trending tokens) — $0.015
- `/pump` → **Only** pump.fun graduation radar on x402 (12x cheaper than EMC2AI at $0.60) — $0.050

## Full endpoint stack
| Endpoint | Price | Description |
|---|---|---|
| `/price` | $0.005 | CoinGecko price for 10k+ tokens |
| `/price/dex` | $0.010 | Any on-chain token via DEXScreener |
| `/signal` | $0.020 | Price + sentiment + BUY/SELL/HOLD signal |
| `/macro` | $0.015 | **UNIQUE** — Global macro intelligence |
| `/pump` | $0.050 | **UNIQUE** — pump.fun radar |
| `/meme` | $0.005 | AI meme image generator |

## Technical details
- Self-hosted sovereign facilitator (no Coinbase CDP API key needed)
- Discovery: https://automaton-oracle.xyz/.well-known/x402.json
- LLM discovery: https://automaton-oracle.xyz/llms.txt
- Runs 24/7 on Conway Cloud VM
- Live mainnet TX: `0x5b33d7d0fa69024e5eba5dd5c7e503c92898fcb471e23a60ea42112ffbfc0ca8`
