### PR TITLE
Add x402 Dynamic Pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Full working examples and templates.
 - [Video Paywall](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required) - Premium content access tutorial.
 - Browser Wallet Template - React + Hono + Session management.
 - [x402 Boilerplate — Conflux eSpace](https://github.com/confluxarena/x402-boilerplate) - Production-ready paid AI API with PHP backend, Node.js facilitator, CLI agent, Docker, 87 tests, and multi-wallet demo. EIP-3009 USDT0 settlement. [Live Demo](https://confluxarena.org/x402-demo).
+- [x402 Dynamic Pricing](https://github.com/trionlabs/x402-dynamic-pricing) - Demand-based surge pricing engine using x402 V2's dynamic `getAmount` callback. Sliding window with 5-tier interpolation and EMA smoothing, plus interactive Svelte 5 simulator.
 
 ### API Examples
 


### PR DESCRIPTION
## Add x402 Dynamic Pricing

**What:** Reference implementation of demand-based surge pricing for x402 V2.

**Why:** Demonstrates x402 V2's dynamic pricing callback (`getAmount`), a key V2 feature with no existing working example in this list. Includes a deployable Express server, standalone pricing engine, and simulator for visualizing pricing curves under different demand patterns.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Example Applications -> Full-Stack Applications