### PR TITLE
Add Scout MCP - multi-source intelligence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Full working examples and templates.
 ### API Examples
 
 - [Alfred's Digital Bazaar](https://httpay.xyz) - ~100 x402-paywalled API endpoints built by an AI agent. Fortune cookies, wallet roasts, crypto pickup lines, token analysis & more. $0.10–$1.00 USDC per call on Base. No signup required. [Source](https://github.com/Alfredz0x/alfreds-digital-bazaar)
+- [Scout MCP](https://scout.hugen.tokyo) - Multi-source intelligence API for AI agents. Search across Hacker News, GitHub, npm, PyPI, Product Hunt, X/Twitter, and x402 Bazaar in one call. 10 endpoints from $0.001 USDC on Base. [Source](https://github.com/bartonguestier1725-collab/scout-mcp)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 
 ### Client Examples
@@ -301,6 +302,7 @@ Enable AI agents to make autonomous payments.
 - Embedded Wallet MCP - Electron-based wallet for MCP.
 - [MaximumSats MCP](https://github.com/joelklabo/maximumsats-mcp) - Lightning-native MCP tools with L402 micropayments and Nostr Web-of-Trust scoring APIs.
 - [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
+- [Scout MCP](https://scout.hugen.tokyo) - 10-tool MCP server for multi-source intelligence: HN, GitHub, npm, PyPI, Product Hunt, X/Twitter, x402 Bazaar search, and composite reports. $0.001–$0.25 USDC on Base. ([Source](https://github.com/bartonguestier1725-collab/scout-mcp))
 
 ### Agent Frameworks
 


### PR DESCRIPTION
## Summary
- Added Scout MCP to **API Examples** and **Model Context Protocol (MCP)** sections
- 10-tool MCP server and x402 HTTP API for AI agent intelligence
- Searches across HN, GitHub, npm, PyPI, Product Hunt, X/Twitter, and x402 Bazaar
- $0.001–$0.05 USDC per call on Base Mainnet
- Live at https://scout.hugen.tokyo

## Links
- Source: https://github.com/bartonguestier1725-collab/scout-mcp
- Discovery: https://scout.hugen.tokyo/.well-known/x402
- Health: https://scout.hugen.tokyo/health