### PR TITLE
Add MoonMaker API — AI-native crypto data API with x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Full working examples and templates.
 ### API Examples
 
 - [Alfred's Digital Bazaar](https://httpay.xyz) - ~100 x402-paywalled API endpoints built by an AI agent. Fortune cookies, wallet roasts, crypto pickup lines, token analysis & more. $0.10–$1.00 USDC per call on Base. No signup required. [Source](https://github.com/Alfredz0x/alfreds-digital-bazaar)
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 
 ### Client Examples
@@ -449,6 +450,8 @@ Projects building with or extending x402.
 - [thirdweb Nebula](https://thirdweb.com/nebula) - AI agent transaction framework.
 
 ### Tools & Services
+
+- [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto intelligence API. Real-time signals, market regime, institutional flows, DeFi yields & DEX alpha — pay per call via x402 USDC on Base. Built for AI agents.
 
 - [CrossFin](https://crossfin.dev) — x402 Agent Services Gateway with 15 paid Korean market data APIs (Kimchi Premium, KOSPI, Bithumb, Upbit, Coinone, FX, headlines, trading signals). First financial data APIs in the x402 ecosystem. MCP server included.
 - [x402 API Network](https://x402.fatihai.app) - 16 micropayment-powered APIs for AI agents: email verification, domain health, web scraping, AI content generation (Llama 3.3 70B), DNS, WHOIS, SSL check, and more. Includes MCP server, Bazaar discovery, and .well-known/x402 manifest. ([GitHub](https://github.com/fatihdagustu20-hub/x402-api-network))


### PR DESCRIPTION
## What is MoonMaker API?

[MoonMaker API](https://api.moonmaker.cc) is a production x402 pay-per-call crypto intelligence API built specifically for AI agents.

**11 endpoints:**
- `/signal/{coin}` — Multi-indicator trading signal (25 indicators)
- `/context/{coin}` — Raw market context data (25 indicators)
- `/regime` — Current market regime classification
- `/risk/{coin}` — Risk assessment
- `/institutions` — Institutional BTC holdings tracker
- `/market/etf` — Bitcoin ETF flow data
- `/market/overview` — Full market overview
- `/events` — Recent market events
- `/yields` — Top DeFi yield opportunities (18K+ pools)
- `/dex/alpha` — DEX alpha scanner
- `/defi/recommend` — DeFi recommendations

**Pricing:** $0.02–$0.10 USDC per call, Base mainnet  
**No signup, no API key** — pure x402 pay-per-call  
**llms.txt:** https://api.moonmaker.cc/llms.txt (AI agent discovery)

Live since February 2026.