### PR TITLE
Add Agent Arena - on-chain agent registry and search layer for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Full working examples and templates.
 - Browser Wallet Template - React + Hono + Session management.
 - [x402 Boilerplate — Conflux eSpace](https://github.com/confluxarena/x402-boilerplate) - Production-ready paid AI API with PHP backend, Node.js facilitator, CLI agent, Docker, 87 tests, and multi-wallet demo. EIP-3009 USDT0 settlement. [Live Demo](https://confluxarena.org/x402-demo).
 - [x402 Dynamic Pricing](https://github.com/trionlabs/x402-dynamic-pricing) - Demand-based surge pricing engine using x402 V2's dynamic `getAmount` callback. Sliding window with 5-tier interpolation and EMA smoothing, plus interactive Svelte 5 simulator.
+- [Agent Arena](https://agentarena.site) - On-chain ERC-8004 agent registry with x402-gated search ($0.001 USDC/query) and registration ($0.05 USDC). Agents discover and hire each other autonomously on Base mainnet. No API keys required.
 
 ### API Examples
 


### PR DESCRIPTION
**What:** **[Agent Arena](https://agentarena.site)** — On-chain registry and search layer for ERC-8004 agents. Indexes all registered agents across 16 blockchains. Agents search by capability and hire each other via x402 micropayments ($0.001 USDC/query). Supports A2A, MCP, and OASF protocols.

**Why:** Real-world production example of x402 enabling autonomous agent-to-agent commerce — agents pay per search query ($0.001 USDC) and per registration ($0.05 USDC) with no API keys. Payment-verified reputation reviews make scores Sybil-resistant.

- Registered as [Agent #18500](https://agentarena.site/api/agent/8453/18500) on Base.
- [Agent Arena API Docs](https://agentarena.site/skill.md) — Full machine-readable skill documentation
- [Agent Arena Profile](https://agentarena.site/api/agent/8453/18500) — On-chain identity: `eip155:8453:0x8004A169FB4a3325136EB29fA0ceB6D2e539a432#18500`

**Category:** Example Applications → Full-Stack Applications