### PR TITLE
Add Mailcheck API to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Full working examples and templates.
 - [Gotobi Calendar API](https://gotobi.hugen.tokyo) - Japanese FX gotobi date intelligence for AI trading agents. Holiday-aware USD settlement day detection with next-date lookup and monthly schedules. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-gotobi-api)
 - [Weather API](https://weather.hugen.tokyo) - Global weather data for AI agents. Real-time conditions and 7-day forecasts for any city worldwide. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-weather-api)
 - [Scout MCP](https://scout.hugen.tokyo) - Multi-source intelligence API for AI agents. Search across Hacker News, GitHub, npm, PyPI, Product Hunt, X/Twitter, and x402 Bazaar in one call. 10 endpoints from $0.001 USDC on Base. [Source](https://github.com/bartonguestier1725-collab/scout-mcp)
+- [Mailcheck API](https://mailcheck.hugen.tokyo) - Email validation for AI agents. Syntax, MX records, disposable domain detection, free provider check, role-based address detection, and typo suggestion. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-mailcheck-api)
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 


### PR DESCRIPTION
## Summary

- Added [Mailcheck API](https://mailcheck.hugen.tokyo) to Tools & Services section
- Email validation for AI agents: syntax, MX records, disposable domain detection, free provider check, role-based address detection, and typo suggestion
- $0.001 USDC per call on Base Mainnet
- Live and verified on Bazaar Discovery

## Verification

- Health check: `curl https://mailcheck.hugen.tokyo/health` → 200
- Paid endpoints return 402 as expected
- x402 discovery: `curl https://mailcheck.hugen.tokyo/.well-known/x402` → 3 resources listed