### PR TITLE
Add Intelligence Aeternum - monetized MCP data marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Enable AI agents to make autonomous payments.
 - [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
 - [Pylon MCP Server](https://www.npmjs.com/package/@pylonapi/mcp) - 20-tool MCP server for utility APIs: web extraction, search, translation, code execution, image generation, email, and more. `npx @pylonapi/mcp`. ([GitHub](https://github.com/pylon-apis/pylon-mcp))
 - [Scout MCP](https://scout.hugen.tokyo) - 10-tool MCP server for multi-source intelligence: HN, GitHub, npm, PyPI, Product Hunt, X/Twitter, x402 Bazaar search, and composite reports. $0.001–$0.25 USDC on Base. ([Source](https://github.com/bartonguestier1725-collab/scout-mcp))
+- [Intelligence Aeternum](https://github.com/codex-curator/intelligence-aeternum-mcp) - First monetized MCP server marketplace. 2M+ museum artworks with x402 USDC micropayments on Base L2. 16 MCP tools for search, enrichment, and delivery. [Live](https://data-portal-172867820131.us-west1.run.app/mcp)
 
 ### Agent Frameworks
 


### PR DESCRIPTION
## Add Intelligence Aeternum MCP Server

Adds [Intelligence Aeternum](https://github.com/codex-curator/intelligence-aeternum-mcp) to the **Model Context Protocol (MCP)** section under AI Agent Integration.

**What it is:** The first monetized MCP server data marketplace, providing access to 2M+ museum artworks across 7 institutions with x402 USDC micropayments on Base L2.

**16 MCP tools** covering:
- Multi-institution artwork search
- 111-field Golden Codex enrichment metadata
- Collection browsing and statistics
- Batch delivery pipelines

**x402 Integration:**
- USDC micropayments on Base L2
- Pay-per-query pricing
- Standard x402 payment flow

- [GitHub Repository](https://github.com/codex-curator/intelligence-aeternum-mcp)
- [Live MCP Endpoint](https://data-portal-172867820131.us-west1.run.app/mcp)
- [Data Portal](https://data-portal-172867820131.us-west1.run.app)