### PR TITLE
Add DJD AgentScore – reputation scoring for x402 agent wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Projects building with or extending x402.
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto intelligence API. Real-time signals, market regime, institutional flows, DeFi yields & DEX alpha — pay per call via x402 USDC on Base. Built for AI agents.
 - [Bloomfilter](https://bloomfilter.xyz) - x402-powered domain registration API for AI agents. Register ICANN domains and manage DNS, paying with USDC on Base
 - [OpSpawn Bazaar](https://a2a.opspawn.com) - Suite of seven AI-powered x402 microservices including screenshot capture, sentiment analysis, summarization, translation, fact-checking, and entity extraction on Base network.
+- [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) – On-chain reputation scoring API for AI agent wallets. Returns a 0–100 trust score across 5 dimensions (identity, behavior, reliability, viability, capability) from x402 settlement history on Base. Free tier, no signup.
 
 ### DeFi & Finance
 


### PR DESCRIPTION
## Summary

- Adds **DJD AgentScore** to the **Tools & Services** section under Ecosystem Projects.
- AgentScore is an on-chain reputation scoring API that returns a 0–100 trust score for AI agent wallets, computed across 5 dimensions: identity, behavior, reliability, viability, and capability.
- Scores are derived from x402 settlement history on Base, making it directly relevant to the x402 ecosystem — it helps agents and services assess counterparty trustworthiness before transacting.
- Free tier, no signup required.

## Why this is relevant to x402

As the x402 ecosystem grows with hundreds of agent-to-agent payment services, trust becomes a critical infrastructure layer. AgentScore provides a standardized way for x402 participants to evaluate agent reputation based on actual on-chain settlement behavior, reducing fraud risk and enabling more confident autonomous transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)