### PR TITLE
Add x402 AI API (zeroreader) — 29 Cloudflare Workers AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Full working examples and templates.
 - [Scout MCP](https://scout.hugen.tokyo) - Multi-source intelligence API for AI agents. Search across Hacker News, GitHub, npm, PyPI, Product Hunt, X/Twitter, and x402 Bazaar in one call. 10 endpoints from $0.001 USDC on Base. [Source](https://github.com/bartonguestier1725-collab/scout-mcp)
 - [Mailcheck API](https://mailcheck.hugen.tokyo) - Email validation for AI agents. Syntax, MX records, disposable domain detection, free provider check, role-based address detection, and typo suggestion. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-mailcheck-api)
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
+- [x402 AI API — zeroreader](https://api.zeroreader.com) - 29 Cloudflare Workers AI models (LLM, Embeddings, Image Generation, Audio, Translation) via x402 micropayments. $0.001–$0.015 per request, USDC on Base. Supports streaming, batch processing, OpenAI-compatible format. [llms.txt](https://api.zeroreader.com/llms.txt) | [OpenAPI](https://api.zeroreader.com/openapi.json)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 
 ### Client Examples


### PR DESCRIPTION
## Summary

Adding **x402 AI API by zeroreader** to the API Examples section.

### What is it?

A production x402 API serving **29 Cloudflare Workers AI models** across 5 categories:
- **17 LLMs** (Llama, Mistral, Qwen, Gemma, DeepSeek R1, GPT-OSS, and more)
- **4 Embedding models** (BGE-M3 multilingual, BGE Large/Small, Qwen3)
- **1 Image generation** (FLUX.1 Schnell)
- **3 Audio** (Whisper STT, Whisper Large v3, MeloTTS)
- **3 Other** (Translation, Reranker, Sentiment)
- **Batch endpoint** (up to 10 requests per batch)

### Key features
- **$0.001-$0.015** per request, USDC on Base
- **OpenAI-compatible** response format
- **Streaming support** for LLMs
- **No API keys** — pure x402 pay-per-request
- Full discovery endpoints

### Links
- API: https://api.zeroreader.com
- Models: https://api.zeroreader.com/v1/models
- OpenAPI: https://api.zeroreader.com/openapi.json
- llms.txt: https://api.zeroreader.com/llms.txt
- x402 Discovery: https://api.zeroreader.com/.well-known/x402.json