### PR TITLE
Update x402 Discovery entries: fix tool count, add Payment Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Projects building with or extending x402.
 - [dTelecom STT](https://x402stt.dtelecom.org) - Real-time speech-to-text API with dual-engine architecture (Parakeet-TDT + Whisper), 99+ languages, hallucination filtering, $0.005/min. Built on dTelecom DePIN. [Python SDK](https://github.com/dTelecom/stt-client-python) | [TypeScript SDK](https://github.com/dTelecom/stt-client-ts)
 - [BlockRun](https://blockrun.ai) - AI Gateway + Service Directory with 600+ x402 services indexed, trust scores, and 31+ AI models via pay-per-use USDC.
 - [x402 Service Discovery API](https://x402-discovery-api.onrender.com) - Enriched directory of 251+ x402-payable services with trust signals, uptime tracking, latency metrics, and health scores. Auto-scans x402.org/ecosystem + awesome-x402 every 6h. Companion MCP server with 6 tools (x402_discover, x402_trust, x402_health_check, x402_route, etc.). Smart routing via [RouteNet](https://x402-routenet.onrender.com).
+- [x402 RouteNet](https://x402-routenet.onrender.com) - Smart routing layer for x402-enabled services. Selects the optimal endpoint from 251+ indexed services based on price, latency, health score, or composite trust. Four routing strategies: `best` (composite score), `cheapest`, `fastest`, `most_trusted`. Works with the Discovery API — discover services, then route to the best one. ([GitHub](https://github.com/rplryan/x402-routenet))
 - Apexti Toolbelt - 1,500+ Web3 APIs via x402 MCP servers.
 - [Zyte.com](https://www.zyte.com) - Web scraping with x402 payments.
 - BuffetPay - Smart x402 payments with guardrails.


### PR DESCRIPTION
**Updates to existing x402scout entries:**

1. **x402 Service Discovery MCP** (was merged in PR #56)
   - Updated tool count: 4 → 6 tools (added `x402_facilitator_check`, `x402_route`)
   - Added Smithery 100/100 score + Docker image reference
   - Removed stale demo.html link

2. **x402 Service Discovery API**
   - Updated to 251+ services (was listing old count)
   - Removed incorrect `pip install x402discovery` reference (that's not the package name)
   - Added note about auto-scanning every 6h and RouteNet companion

3. **Added x402 Payment Harness** to Python → Client Libraries section
   - `pip install x402-payment-harness`
   - Works with any Ethereum EOA — no Coinbase CDP wallet required
   - Full HTTP 402 → EIP-712 sign → X-PAYMENT header flow
   - Live on PyPI: https://pypi.org/project/x402-payment-harness/