### PR TITLE
Add ClawPay MCP and Agent Wallet SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ Client libraries for making x402 payments.
 
 **AI Agent SDKs**
 - [PayBot SDK](https://github.com/RBKunnela/paybot-sdk) - TypeScript SDK for integrating x402 payments into AI agents and bots. Supports automatic 402 detection, wallet management, and USDC payments on Base. ([npm](https://www.npmjs.com/package/paybot-sdk))
+- [ClawPay MCP](https://www.npmjs.com/package/clawpay-mcp) - Non-custodial x402 payment layer for AI agents. Agents sign locally with their own keys — no custodial infrastructure needed. Supports automatic 402 detection and USDC payments on Base. ([npm](https://www.npmjs.com/package/clawpay-mcp))
 
 **Wallet Integration**
+- [Agent Wallet SDK](https://www.npmjs.com/package/agentwallet-sdk) - Non-custodial smart contract wallets for AI agents with on-chain spend limits and operator model. Base L2. ([npm](https://www.npmjs.com/package/agentwallet-sdk))
 - [viem](https://viem.sh/) - TypeScript library used for signing payments.
 - [ethers.js](https://docs.ethers.org/) - Alternative Ethereum library.
 


### PR DESCRIPTION
Hey! Adding two open-source tools we built for the x402 ecosystem:

**ClawPay MCP** — Non-custodial x402 payment layer where AI agents sign transactions locally with their own keys. No custodial infrastructure. Handles 402 detection and USDC payments on Base.
- npm: `clawpay-mcp` (v1.0.0)
- MIT license

**Agent Wallet SDK** — Smart contract wallets designed for AI agents, with on-chain spend limits enforced by the operator model. Pairs naturally with x402 for agent payments.
- npm: `agentwallet-sdk` (v2.0.1)
- 267 tests, MIT license
- Deployed on Base L2

Both are actively maintained and used in production agent systems. Happy to adjust formatting if needed!