### PR TITLE
Add Agentic Signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,3 +693,5 @@ Looking for more awesome lists?
   <a href="https://discord.gg/x402">Discord</a> •
   <a href="https://twitter.com/x402org">Twitter</a>
 </p>
+
+- Agentic Signal — paid BTC/ETH DCA signal API (x402 USDC on Base) + signed responses + proof/backtests. Docs: https://signal.agenticsignal.dev/docs


### PR DESCRIPTION
Adds Agentic Signal to the x402 ecosystem list.

Docs: https://signal.agenticsignal.dev/docs
Skill: https://signal.agenticsignal.dev/agentic-signal.skill
Demo: https://github.com/alphagrit/agentic-signal-demo-agent
