### PR TITLE
Add Human Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Enable AI agents to make autonomous payments.
 - [x402 Service Discovery MCP](https://github.com/rplryan/x402-discovery-mcp) - MCP server enabling agents to discover x402-payable APIs at runtime with quality signals (uptime, latency, health scores). 4 tools: discover, browse, health check, register. Live demo at https://rplryan.github.io/ouroboros/demo.html
 - [PayBot MCP](https://github.com/RBKunnela/paybot-mcp) - MCP server enabling Claude and AI agents to make autonomous x402 payments. Supports wallet management, transaction history, and configurable spending limits. ([npm](https://www.npmjs.com/package/paybot-mcp))
 
+- [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Supports x402 pay-per-use for profile views ($0.05) and job offers ($0.25) in USDC on Base. Also available as an [MCP server](https://github.com/human-pages-ai/humanpages) with 31 tools.
+
 ### Agent Frameworks
 
 - [NEAR AI](https://near.ai) - Cross-chain agent settlements.


### PR DESCRIPTION
Adds [Human Pages](https://humanpages.ai) to the AI Agent Integration section. Supports x402 pay-per-use for profile views ($0.05) and job offers ($0.25) in USDC on Base. Also available as an MCP server with 31 tools.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages