### PR TITLE
Add Content Intelligence API to API Examples and Content & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Full working examples and templates.
 - [Mailcheck API](https://mailcheck.hugen.tokyo) - Email validation for AI agents. Syntax, MX records, disposable domain detection, free provider check, role-based address detection, and typo suggestion. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-mailcheck-api)
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - [x402 AI API — zeroreader](https://api.zeroreader.com) - 29 Cloudflare Workers AI models (LLM, Embeddings, Image Generation, Audio, Translation) via x402 micropayments. $0.001–$0.015 per request, USDC on Base. Supports streaming, batch processing, OpenAI-compatible format. [llms.txt](https://api.zeroreader.com/llms.txt) | [OpenAPI](https://api.zeroreader.com/openapi.json)
+- [Content Intelligence API](https://content.hugen.tokyo) - AI-powered web content extraction and analysis for AI agents. Clean text extraction with trafilatura (F1=0.909), metadata/OG tags, link classification, AI summarization with key points and entity extraction, full sentiment/topic/credibility analysis via Gemini. 5 endpoints from $0.003 USDC on Base.
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 
 ### Client Examples
@@ -263,6 +264,7 @@ Real-world use cases and implementation patterns. The x402 protocol has seen **1
 - Compute resource allocation
 
 **Content & Media**
+- AI content extraction and analysis ([Content Intelligence API](https://content.hugen.tokyo))
 - Per-article paywalls
 - Video streaming (pay-per-view)
 - Music licensing per play


### PR DESCRIPTION
## Summary

- Added [Content Intelligence API](https://content.hugen.tokyo) to API Examples and Content & Media sections
- AI-powered web content extraction and analysis: clean text extraction (trafilatura F1=0.909), metadata/OG tags, link classification, AI summarization with entity extraction, full sentiment/topic/credibility analysis via Gemini
- 5 endpoints: metadata ($0.003), links ($0.003), extract ($0.005), summary ($0.01), analyze ($0.02) USDC on Base Mainnet
- Live and verified on Bazaar Discovery

## Verification

- Health check: `curl https://content.hugen.tokyo/health` → 200
- Paid endpoints return 402 as expected
- x402 discovery: `curl https://content.hugen.tokyo/.well-known/x402` → 5 resources listed