### PR TITLE
Add Paybound — spending controls for x402 agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Development tools and utilities for x402.
 - [Sentinel](https://sentinel.valeocash.com) - Enterprise audit & compliance layer for x402 payments. Budget enforcement (per-call, hourly, daily), structured audit trails, real-time dashboard, and public payment explorer. SDK: [`@x402sentinel/x402`](https://npmjs.com/package/@x402sentinel/x402). Built by [Valeo](https://valeocash.com)
 
 - [ScoutScore](https://scoutscore.ai) - Trust scoring infrastructure for x402 services. Monitors 1,700+ services with continuous health checks and fidelity probes using a 4-pillar model (Contract Clarity, Availability, Response Fidelity, Identity & Safety). [API Docs](https://scoutscore.ai/docs) · [npm SDK](https://www.npmjs.com/package/@scoutscore/sdk) · [MCP Server](https://www.npmjs.com/package/@scoutscore/mcp-server)
+- [Paybound](https://github.com/pando-b/paybound) - Open-source governance proxy for x402 agent payments. Per-agent budgets, circuit breakers, and SQLite audit trail.
 
 ## 🧪 Testing & Development
 
@@ -599,6 +600,7 @@ Security resources and best practices for x402 implementations.
 
 ### Spending Controls & Policy Enforcement
 
+- [Paybound](https://github.com/pando-b/paybound) - Open-source spending controls for AI agents making x402 payments. Per-agent budgets, time-windowed limits, circuit breakers, and full audit trail. Drop-in `@x402/fetch` replacement. MIT licensed.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforces daily spending limits, per-transaction caps, recipient whitelists, and rate limiting without holding private keys.
 
 ## 🔗 Related Protocols


### PR DESCRIPTION
## What is Paybound?

[Paybound](https://github.com/pando-b/paybound) is an open-source governance layer for AI agents making x402 payments.

**Problem:** Once an agent can pay autonomously via x402, there's no standard way to prevent it from overspending. A single bug in an agent loop can drain a wallet.

**Solution:** Paybound is a transparent proxy that enforces spending controls without custodying funds or redirecting payments:

- Per-agent budgets (daily/weekly/monthly limits in USDC)
- Time-windowed rate limiting
- Circuit breaker (auto-pause on spending spikes)
- Full SQLite audit trail
- Drop-in replacement for `@x402/fetch`

**Details:**
- License: MIT
- Language: TypeScript
- Tests: 23 passing
- No fund custody, no payment redirection — pure governance

**Sections added:**
- 🔒 Spending Controls & Policy Enforcement
- 🔨 Tools & Utilities → Monitoring & Analytics

Happy to adjust placement or description per your guidelines!