### PR TITLE
Add Intel API — AI-synthesized token due diligence reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Full working examples and templates.
 - [Mailcheck API](https://mailcheck.hugen.tokyo) - Email validation for AI agents. Syntax, MX records, disposable domain detection, free provider check, role-based address detection, and typo suggestion. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-mailcheck-api)
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - [x402 AI API — zeroreader](https://api.zeroreader.com) - 29 Cloudflare Workers AI models (LLM, Embeddings, Image Generation, Audio, Translation) via x402 micropayments. $0.001–$0.015 per request, USDC on Base. Supports streaming, batch processing, OpenAI-compatible format. [llms.txt](https://api.zeroreader.com/llms.txt) | [OpenAPI](https://api.zeroreader.com/openapi.json)
+- [Intel API](https://intel.hugen.tokyo) - AI-synthesized token due diligence reports for crypto assets. Aggregates 4 GoPlus security checks + CoinGecko market data into risk-scored verdicts with red/green flags and recommendations. One call replaces 5+ separate security APIs. $0.50 USDC per call on Base.
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 
 ### Client Examples


### PR DESCRIPTION
## Summary
- Adds Intel API (https://intel.hugen.tokyo) to API Examples section
- AI-synthesized token due diligence: 4 GoPlus security checks + CoinGecko + Gemini AI verdict
- $0.50 USDC per call on Base (x402 v2)
- One call returns risk score (0-100), red/green flags, and actionable recommendations

## Verification
- Live at https://intel.hugen.tokyo/.well-known/x402
- Health: https://intel.hugen.tokyo/health
- ClawMart verified (#480)