### PR TITLE
Add x402 Charity

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,10 @@ Projects building with or extending x402.
 - [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) – On-chain reputation scoring API for AI agent wallets. Returns a 0–100 trust score across 5 dimensions (identity, behavior, reliability, viability, capability) from x402 settlement history on Base. Free tier, no signup.
 - [SIBYL](https://sibylcap.com) - Autonomous crypto intelligence agent on Base. Three x402 endpoints: token scoring ($0.05), rug/honeypot detection ($0.02), and builder shipping velocity vs. market cap analysis ($0.10). ERC-8004 registered (Agent #20880). USDC on Base. Discovery: [Agent Card](https://sibylcap.com/8004.json) | [Domain Verification](https://sibylcap.com/.well-known/agent-registration.json)
 
+### Charity & Social Impact
+
+- [x402 Charity](https://allscale-io.github.io/x402charity/) - Open-source middleware for automatic micro-donations via x402. Embed charitable giving into any payment flow — trades, API calls, subscriptions. $0.0001 USDC per event on Base. CLI + web widget. Built by [AllScale Lab](https://allscale.io). ([GitHub](https://github.com/allscale-io/x402charity))
+
 ### DeFi & Finance
 
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.


### PR DESCRIPTION
## Summary
- Adds **x402 Charity** under a new "Charity & Social Impact" category in Ecosystem Projects
- Open-source middleware for automatic micro-donations via x402 protocol
- Embed charitable giving into any payment flow (trades, API calls, subscriptions)
- $0.0001 USDC per event on Base
- CLI + web donation widget
- Built by [AllScale Lab](https://allscale.io)

**Links:**
- Live demo: https://allscale-io.github.io/x402charity/
- GitHub: https://github.com/allscale-io/x402charity