### PR TITLE
Add PortsideLabs Places API

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Full working examples and templates.
 - [MoonMaker API](https://api.moonmaker.cc) - AI-native crypto data API with x402 pay-per-call. 11 endpoints: signals, market context, DeFi regime, institutions, ETF flows, DeFi yields, DEX alpha. $0.02–$0.10/call USDC on Base. No signup. [llms.txt](https://api.moonmaker.cc/llms.txt)
 - [x402 AI API — zeroreader](https://api.zeroreader.com) - 29 Cloudflare Workers AI models (LLM, Embeddings, Image Generation, Audio, Translation) via x402 micropayments. $0.001–$0.015 per request, USDC on Base. Supports streaming, batch processing, OpenAI-compatible format. [llms.txt](https://api.zeroreader.com/llms.txt) | [OpenAPI](https://api.zeroreader.com/openapi.json)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
+- [PortsideLabs Places API](https://portsidelabs-x402-places-536698811508.us-west1.run.app) - Google Places API v1 proxy with x402 pay-per-request access. Exposes place detail lookup and full-text search via USDC micropayments on Base mainnet and Solana mainnet. $0.001 USDC per call.
 
 ### Client Examples
 


### PR DESCRIPTION
## Add PortsideLabs Places API

**What:** Adding the PortsideLabs Places API — an Express.js server that proxies Google Places API v1 (place detail lookup and full-text search) behind an x402 payment layer.

**Why:** Demonstrates a production-ready x402 pay-per-request proxy for a well-known third-party API (Google Places). Useful for developers looking to monetize Google Places access or see a multi-chain x402 implementation (Base mainnet + Solana mainnet) with a self-hosted facilitator.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Example Applications → API Examples