### PR TITLE
Add ICME Labs — formal verification + zkML for AI agent guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ Security resources and best practices for x402 implementations.
 
 - [Paybound](https://github.com/pando-b/paybound) - Open-source spending controls for AI agents making x402 payments. Per-agent budgets, time-windowed limits, circuit breakers, and full audit trail. Drop-in `@x402/fetch` replacement. MIT licensed.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforces daily spending limits, per-transaction caps, recipient whitelists, and rate limiting without holding private keys.
+- [ICME Labs](https://docs.icme.io) - Formal verification for AI agent actions using the ARc paper approach. Natural language policies compile to SMT-LIB formal logic, checked by an SMT solver — SAT = allowed, UNSAT = blocked. Wrapped in zero knowledge proofs for sub-1s verification, private policies, and  cryptographic audit trails per decision. 99%+ soundness under adversarial pressure. $0.10 USDC per check on Base, no account needed. Live demo policy available. 
 
 ## 🔗 Related Protocols
 


### PR DESCRIPTION
ICME Labs compiles natural language policies to SMT-LIB formal logic via the ARc (https://arxiv.org/pdf/2511.09008) approach and checks agent actions against an SMT solver. The solver cannot be argued out of a decision — 
unlike LLM judges and prompt-based guardrails, soundness does not degrade under adversarial pressure.

Zero knowledge proofs (https://github.com/ICME-Lab/jolt-atlas) wrap every decision for sub-1s verification, private policies, and  cryptographic audit trails.

- /v1/verifyPaid endpoint open to third parties with any policy_id
- Live demo policy to test against: f6e3cd15-9e28-45c4-9f4c-683edd63e468