### PR TITLE
Add x402charity — open-source micro-donation server

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Projects building with or extending x402.
 - [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) – On-chain reputation scoring API for AI agent wallets. Returns a 0–100 trust score across 5 dimensions (identity, behavior, reliability, viability, capability) from x402 settlement history on Base. Free tier, no signup.
 - [SIBYL](https://sibylcap.com) - Autonomous crypto intelligence agent on Base. Three x402 endpoints: token scoring ($0.05), rug/honeypot detection ($0.02), and builder shipping velocity vs. market cap analysis ($0.10). ERC-8004 registered (Agent #20880). USDC on Base. Discovery: [Agent Card](https://sibylcap.com/8004.json) | [Domain Verification](https://sibylcap.com/.well-known/agent-registration.json)
 
+- [x402charity](https://x402charity.com) — Open-source micro-donation server powered by x402. Drop-in Express/Next.js middleware that triggers USDC charity donations on every user action (API call, trade, game move). npm package, CLI, and Vercel-deployable server with built-in dashboard. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
 ### DeFi & Finance
 
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.


### PR DESCRIPTION
## What is x402charity?

[x402charity](https://x402charity.com) is an open-source micro-donation server powered by x402. It lets any company add automated USDC micro-donations to their product — a trade, an API call, or a game move can trigger a small donation to charity on Base.

**Key features:**
- Drop-in Express/Next.js middleware
- CLI tool (`npx x402charity donate`)
- Vercel-deployable server with built-in dashboard
- Fire-and-forget — non-blocking donations
- Sub-cent donations viable on Base L2

**Links:**
- Website: https://x402charity.com
- GitHub: https://github.com/allscale-io/x402charity
- npm: https://www.npmjs.com/package/x402charity

Added under **Ecosystem Projects > Tools & Services** as it provides x402-powered infrastructure for charitable micro-donations.