### PR TITLE
Add ag402 payment layer and token-rugcheck MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Official and community implementations of the x402 protocol.
   - Requests session with auto-payments
   - Payment requirement generation
 
+- [ag402](https://github.com/AetherCore-Dev/ag402) ⭐ **Community** - Payment layer for AI agents using Coinbase x402 protocol. Wrap any API or MCP server with a USDC paywall in one command (`ag402 serve`), or let agents auto-pay for paid APIs (`ag402 run`). Solana USDC, ~0.5s settlement, non-custodial, 648+ tests. Works with Claude Code, Cursor, OpenClaw, LangChain, AutoGen out of the box. [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/ag402-mcp)** - Python SDK on PyPI.
+  - FastAPI middleware integration
+  - Requests session with auto-payments
+  - Payment requirement generation
+
 ### Rust
 
 - [x402-rs](https://github.com/x402-rs/x402-rs) ⭐ **Community** - Production-grade Rust implementation.
@@ -331,6 +336,7 @@ Enable AI agents to make autonomous payments.
 - [Scout MCP](https://scout.hugen.tokyo) - 10-tool MCP server for multi-source intelligence: HN, GitHub, npm, PyPI, Product Hunt, X/Twitter, x402 Bazaar search, and composite reports. $0.001–$0.25 USDC on Base. ([Source](https://github.com/bartonguestier1725-collab/scout-mcp))
 - [Intelligence Aeternum](https://github.com/codex-curator/intelligence-aeternum-mcp) - First monetized MCP server marketplace. 2M+ museum artworks with x402 USDC micropayments on Base L2. 16 MCP tools for search, enrichment, and delivery. [Live](https://data-portal-172867820131.us-west1.run.app/mcp)
 - [x402 Service Discovery MCP](https://github.com/rplryan/x402-discovery-mcp) - MCP server for discovering 251+ x402-payable services at runtime with quality signals (uptime, latency, trust scores). 6 tools: x402_discover, x402_health_check, x402_trust, x402_register, x402_facilitator_check, x402_route. Smithery 100/100. Docker: `ghcr.io/rplryan/x402-discovery-mcp:latest`
+- [AetherCore-Dev/token-rugcheck](https://github.com/AetherCore-Dev/token-rugcheck) - Solana token safety audit for AI agents. Three-layer risk analysis (machine verdict + LLM analysis + raw on-chain evidence) from RugCheck.xyz, DexScreener, and GoPlus Security. Live on mainnet with USDC micropayments ($0.02/audit) via x402 protocol. [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/token-rugcheck)
 - [Harvey Intel](https://agents.rugslayer.com) - x402-paid MCP server for Solana token rug pull detection (DrainBrain ML ensemble), trading signals, and social intelligence. 8 tools, $0.005–0.05 USDC on Solana. ([GitHub](https://github.com/meltingpixelsai/harvey-intel)) | ([npm](https://www.npmjs.com/package/@meltingpixels/harvey-intel))
 - [Harvey Tools](https://tools.rugslayer.com) - x402-paid MCP server for web scraping, screenshots, structured data extraction, code review, content generation, and sentiment analysis. 8 tools, $0.005–0.05 USDC on Solana. ([GitHub](https://github.com/meltingpixelsai/harvey-tools)) | ([npm](https://www.npmjs.com/package/@meltingpixels/harvey-tools))
 - [Harvey Verify](https://verify.rugslayer.com) - x402-paid MCP server for post-transaction outcome verification using LLM-as-judge. Tracks aggregated service quality scores. 5 tools, $0.002–0.01 USDC on Solana. ([GitHub](https://github.com/meltingpixelsai/harvey-verify)) | ([npm](https://www.npmjs.com/package/@meltingpixels/harvey-verify))
@@ -497,6 +503,7 @@ Projects building with or extending x402.
 ### Tools & Services
 
 - [Pylon](https://pylonapi.com) — x402-payable utility API gateway for AI agents. 20 capabilities (web extraction, search, translation, code execution, image generation, and more) on Base mainnet. MCP server (`npx @pylonapi/mcp`), agent reputation network, and gateway orchestration. USDC on Base. ([GitHub](https://github.com/pylon-apis/pylon-mcp))
+- [AetherCore-Dev/token-rugcheck](https://github.com/AetherCore-Dev/token-rugcheck) - Solana token safety audit API. Three-layer risk analysis: machine verdict, LLM analysis, raw on-chain evidence. $0.02 USDC/audit. [Live](https://rugcheck.aethercore.dev)
 - [CrossFin](https://crossfin.dev) — x402 Agent Services Gateway with 15 paid Korean market data APIs (Kimchi Premium, KOSPI, Bithumb, Upbit, Coinone, FX, headlines, trading signals). First financial data APIs in the x402 ecosystem. MCP server included.
 - [x402 API Network](https://x402.fatihai.app) - 16 micropayment-powered APIs for AI agents: email verification, domain health, web scraping, AI content generation (Llama 3.3 70B), DNS, WHOIS, SSL check, and more. Includes MCP server, Bazaar discovery, and .well-known/x402 manifest. ([GitHub](https://github.com/fatihdagustu20-hub/x402-api-network))
 - [dTelecom STT](https://x402stt.dtelecom.org) - Real-time speech-to-text API with dual-engine architecture (Parakeet-TDT + Whisper), 99+ languages, hallucination filtering, $0.005/min. Built on dTelecom DePIN. [Python SDK](https://github.com/dTelecom/stt-client-python) | [TypeScript SDK](https://github.com/dTelecom/stt-client-ts)


### PR DESCRIPTION
Adding two production-ready x402 implementations:

**ag402** - Payment layer for AI agents
- Wrap any API or MCP server with USDC paywall in one command
- Solana USDC, ~0.5s settlement, non-custodial
- 648+ tests, MIT licensed
- [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/ag402-mcp)

**token-rugcheck** - Solana token safety audit MCP server
- Three-layer risk analysis: machine verdict + LLM analysis + raw evidence
- Data sources: RugCheck.xyz + DexScreener + GoPlus
- Live on mainnet: /bin/zsh.02 USDC/audit
- [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/token-rugcheck)

Listed in: Python implementations, MCP servers, DeFi & Finance.