### PR TITLE
Add SkillMint to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ Projects building with or extending x402.
 - [APIMesh](https://apimesh.xyz) — 14 x402-payable web analysis APIs for AI agents. SEO audit, security headers, Core Web Vitals, domain availability, email security, email verify, tech stack detection, redirect chains, and more. $0.001–$0.01 per call, USDC on Base. MCP server: `npx @mbeato/apimesh-mcp-server`. ([GitHub](https://github.com/mbeato/conway))
 - [BotIndex](https://king-backend.fly.dev/api/botindex/v1/) - AI-native signal intelligence API with 17 x402 endpoints across 7 domains: sports odds, crypto correlations, token graduations (Zora/Hyperliquid/Metaplex Genesis), DFS optimization, arbitrage detection, and agentic commerce comparison. 50 free premium requests per wallet, then $0.01–$0.50 USDC on Base. MCP server with 17 tools. ([GitHub](https://github.com/Cyberweasel777/King-Backend)) | ([npm](https://npmjs.com/package/botindex-mcp-server)) | ([Discovery](https://king-backend.fly.dev/.well-known/ai-plugin.json))
 
+- [SkillMint](https://skillmint.sagasu.art) - Pay-per-call AI skills marketplace with 51 skills across 7 categories (dev tools, creative design, research, writing, docs). $0.01–$0.50 USDC on Base. No API keys, no subscriptions. ([GitHub](https://github.com/s87343472/skillmint))
+
 ### Charity & Social Impact
 
 - [x402 Charity](https://allscale-io.github.io/x402charity/) - Open-source middleware for automatic micro-donations via x402. Embed charitable giving into any payment flow — trades, API calls, subscriptions. $0.0001 USDC per event on Base. CLI + web widget. Built by [AllScale Lab](https://allscale.io). ([GitHub](https://github.com/allscale-io/x402charity))


### PR DESCRIPTION
## Summary
Adds [SkillMint](https://skillmint.sagasu.art) to the Tools & Services section.

SkillMint is a pay-per-call AI skills marketplace with 51 skills across 7 categories, powered by x402 protocol on Base mainnet (USDC). No API keys, no subscriptions — agents discover, pay, and use skills autonomously.

## Details
- **Live:** https://skillmint.sagasu.art
- **GitHub:** https://github.com/s87343472/skillmint
- **Skills:** 51 across dev tools, creative design, research, writing, SEO, business, document generation
- **Price range:** $0.01–$0.50 USDC per call
- **Stack:** Cloudflare Workers (Hono) + x402 middleware + OpenRouter LLM