### PR TITLE
Add Valoria to Analytics Dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Live metrics and on-chain analytics for the x402 ecosystem.
 
 - [Dune Analytics x402](https://dune.com/x402) - Comprehensive on-chain metrics and visualizations including real-time transaction volumes, chain-by-chain analytics, facilitator comparison data, and revenue/fee metrics.
 - [x402scan Explorer](https://x402scan.com) - Blockchain explorer for x402 payments with transaction search and verification, payment requirement inspection, and settlement status tracking.
+- [Valoria](https://x402.valoria.net) - x402 market intelligence with revenue rankings, service analysis, and pricing data across 90K+ indexed services and $46M+ in tracked on-chain volume.
 - [CoinGecko x402 Category](https://coingecko.com/en/categories/x402) - Token tracking and market data featuring $180M+ tracked market cap, price charts, trading volumes, and ecosystem token listings.
 
 ### Growth Metrics


### PR DESCRIPTION
## Summary

Adds Valoria to the Analytics Dashboards section — x402 market intelligence.

## What it does

Valoria indexes every x402 service, MCP tool, and on-chain payment across Base and Solana — and shows where the money is going.

- **90K+ services indexed** across x402 Bazaar, MCP Registry, and x402scan
- **$46M+ in tracked on-chain volume** from 30+ facilitators
- **28 categories** scored and ranked by real revenue data

## Endpoints

5 paid x402 endpoints, all pay-per-call with USDC on Base:

| Endpoint | Price | Description |
|----------|-------|-------------|
| Market Pulse | $1 | Top earners, hottest categories, total volume, key insight |
| Analyze a Service | $2 | Deep dive — competitors, revenue, ranking, recommendations |
| Pricing Help | $3 | Data-driven pricing recommendation for any category |
| Find Opportunities | $5 | Ranked opportunities with revenue data and gap analysis |
| Market Report | $10 | Full market report — revenue concentration, trends, top earners |

Also available as an MCP server (search_services tool is free).

## Links

- **Website:** https://x402.valoria.net
- **Catalog:** https://x402.valoria.net/catalog
- **Agent Card:** https://x402.valoria.net/.well-known/agent-card.json
- **x402scan:** https://www.x402scan.com/server/972b0fd3-eeb7-4941-ae02-d24ecb3b60c7