### PR TITLE
Add PortsideLabs KoinChappie

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Full working examples and templates.
 - [x402 AI API — zeroreader](https://api.zeroreader.com) - 29 Cloudflare Workers AI models (LLM, Embeddings, Image Generation, Audio, Translation) via x402 micropayments. $0.001–$0.015 per request, USDC on Base. Supports streaming, batch processing, OpenAI-compatible format. [llms.txt](https://api.zeroreader.com/llms.txt) | [OpenAPI](https://api.zeroreader.com/openapi.json)
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 - [PortsideLabs Places API](https://portsidelabs-x402-places-536698811508.us-west1.run.app) - Google Places API v1 proxy with x402 pay-per-request access. Exposes place detail lookup and full-text search via USDC micropayments on Base mainnet and Solana mainnet. $0.001 USDC per call.
+- [PortsideLabs KoinChappie](https://portsidelabs-x402-koinchappie-536698811508.us-west1.run.app) - Crypto signals API with x402 pay-per-request. Returns bull and bear signals for the top 10 cryptocurrencies by market cap across 8 timeframes (1m–1D) using SMA(14). Single-coin lookup supports any CryptoCompare symbol. USDC micropayments on Base mainnet and Solana mainnet. $0.001 USDC per call. 
 
 ### Client Examples
 


### PR DESCRIPTION
## Add PortsideLabs KoinChappie

**What:** Adds PortsideLabs KoinChappie to the API Examples section — a live crypto signals API gated behind x402 pay-per-request. Returns bull and bear signals for the top 10 cryptocurrencies by market cap across 8 timeframes (1m–1D) using SMA(14). Also supports single-coin lookup for any CryptoCompare symbol.

**Why:** A real production x402 deployment demonstrating pay-per-request micropayments for financial data APIs. Supports dual-chain payments — USDC on Base mainnet (EVM/EIP-3009) and Solana mainnet (SPL USDC) — at $0.001 USDC per call. No signup or API key required by the consumer. Useful as a reference for developers building x402-gated data APIs with multi-chain support.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Example Applications → API Examples