### PR TITLE
Add Web3 Signals x402 crypto signal API to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Projects building with or extending x402.
 - [x402 RouteNet](https://x402-routenet.onrender.com) - Smart routing layer for x402-enabled services. Selects the optimal endpoint from 251+ indexed services based on price, latency, health score, or composite trust. Four routing strategies: `best` (composite score), `cheapest`, `fastest`, `most_trusted`. Works with the Discovery API — discover services, then route to the best one. ([GitHub](https://github.com/rplryan/x402-routenet))
 - [Domain Intelligence API](https://domain.hugen.tokyo) - 8-endpoint domain analysis API: WHOIS, DNS (3-resolver parallel), SSL/TLS grading, Wappalyzer tech detection, security headers, CT log subdomains, redirect chains, and full reports. $0.001–$0.02 USDC on Base. ([llms.txt](https://domain.hugen.tokyo/llms.txt))
 - Apexti Toolbelt - 1,500+ Web3 APIs via x402 MCP servers.
+- [Web3 Signals — AgentMarketSignal](https://web3-signals-api-production.up.railway.app) - AI-powered crypto signal intelligence for 20 assets with 6 scoring dimensions (whale, technical, derivatives, narrative, sentiment, market). Market regime detection, portfolio optimization, and accuracy tracking. $0.001 USDC per call on Base. 9 MCP tools (free) + REST API (x402 paid). ([GitHub](https://github.com/manavaga/web3-signals-mcp))
 - [Zyte.com](https://www.zyte.com) - Web scraping with x402 payments.
 - BuffetPay - Smart x402 payments with guardrails.
 - [Cal.com](https://cal.com) - Automated scheduling with payments.


### PR DESCRIPTION
## Summary
Adds **Web3 Signals — AgentMarketSignal** to the Ecosystem Projects > Tools & Services section.

- AI-powered crypto signal intelligence for 20 assets
- x402 micropayments: $0.001 USDC per call on Base L2
- 6 scoring dimensions: whale, technical, derivatives, narrative, sentiment, market
- Market regime detection + portfolio optimization + accuracy tracking
- 9 MCP tools (free) + REST API (x402 paid)

## Links
- Live API: https://web3-signals-api-production.up.railway.app
- GitHub: https://github.com/manavaga/web3-signals-mcp
- MCP: https://web3-signals-api-production.up.railway.app/mcp/sse
- x402 Discovery: https://web3-signals-api-production.up.railway.app/.well-known/mcp.json