### PR TITLE
Add x402-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Development tools and utilities for x402.
 ### CLI Tools
 
 - [Foundry](https://getfoundry.sh/) - Smart contract development toolkit.
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. `npx x402-proxy`. ([npm](https://www.npmjs.com/package/x402-proxy))
 
 ### Monitoring & Analytics
 


### PR DESCRIPTION
## Add x402-proxy

**What:** CLI tool and library for making x402 paid HTTP requests - `curl` for x402.

**Why:** x402-proxy is the only dedicated CLI client for consuming x402-payable APIs. It auto-pays HTTP 402 responses with USDC on Base and Solana, includes an MCP stdio proxy for AI agents, and runs with a single `npx x402-proxy` command. Fills a gap in the CLI Tools section.

**Quality Checklist:**
- [x] Resource is actively maintained
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Tools & Utilities > CLI Tools