### PR TITLE
Add PayCrow — escrow + trust layer for x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Enable AI agents to make autonomous payments.
 - [Intelligence Aeternum](https://github.com/codex-curator/intelligence-aeternum-mcp) - First monetized MCP server marketplace. 2M+ museum artworks with x402 USDC micropayments on Base L2. 16 MCP tools for search, enrichment, and delivery. [Live](https://data-portal-172867820131.us-west1.run.app/mcp)
 - [x402 Service Discovery MCP](https://github.com/rplryan/x402-discovery-mcp) - MCP server enabling agents to discover x402-payable APIs at runtime with quality signals (uptime, latency, health scores). 4 tools: discover, browse, health check, register. Live demo at https://rplryan.github.io/ouroboros/demo.html
 - [PayBot MCP](https://github.com/RBKunnela/paybot-mcp) - MCP server enabling Claude and AI agents to make autonomous x402 payments. Supports wallet management, transaction history, and configurable spending limits. ([npm](https://www.npmjs.com/package/paybot-mcp))
+- [PayCrow](https://github.com/michu5696/paycrow) - Escrow protection for autonomous agent payments. Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution on Base. 10 MCP tools including safe_pay (trust-informed smart escrow) and trust_gate (go/no-go decision before payment). ([npm](https://www.npmjs.com/package/paycrow))
 
 ### Agent Frameworks
 


### PR DESCRIPTION
## Summary

- Adds [PayCrow](https://github.com/michu5696/paycrow) to the **AI Agent Integration > Model Context Protocol (MCP)** section
- PayCrow provides escrow protection for autonomous agent payments on Base
- Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution
- 10 MCP tools including `safe_pay` (trust-informed smart escrow) and `trust_gate` (go/no-go decision before payment)
- Published on npm as [`paycrow`](https://www.npmjs.com/package/paycrow)

## Why it belongs here

PayCrow is the trust and escrow layer for x402 — it wraps x402 payments with on-chain trust scoring and USDC escrow so autonomous agents can pay safely. Open source, on npm, and built specifically for the x402 ecosystem.