### PR TITLE
Add GPU-Bridge: x402-native GPU inference API for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,12 @@ Real-world use cases and implementation patterns. The x402 protocol has seen **1
 
 Enable AI agents to make autonomous payments.
 
+### GPU Inference APIs
+
+x402-native GPU inference APIs that let agents pay autonomously for compute.
+
+- [GPU-Bridge](https://gpubridge.xyz) - 30-service GPU inference API with native x402 payments (USDC on Base L2). LLM, image generation, embeddings, STT, TTS, PDF processing — all in one API. Agents pay per call with no human intervention. /usr/bin/bash.00002/embedding, /usr/bin/bash.001/LLM call. ([Docs](https://docs.gpubridge.xyz)) ([GitHub](https://github.com/fjnunezp75/gpu-bridge))
+
 ### Model Context Protocol (MCP)
 
 - Anthropic MCP Integration - Official Claude integration.


### PR DESCRIPTION
## GPU-Bridge

**GPU-Bridge** is a 30-service GPU inference API with native x402 payments (USDC on Base L2).

**Why it belongs in this list:**
- Real x402 implementation in production — agents pay per inference call with no human intervention
- 30 services: LLM, image generation (FLUX), embeddings (BGE-M3), STT (Whisper), TTS, PDF processing, reranking
- Pricing: $0.00002/embedding call, $0.001/LLM call — competitive with direct provider APIs
- Drop-in API: any agent using OpenAI-compatible format can switch in minutes
- Native USDC on Base L2 — same chain as the rest of the x402 ecosystem

**Links:**
- Website: https://gpubridge.xyz
- Docs: https://docs.gpubridge.xyz
- x402 listing: https://github.com/coinbase/x402/pull/1619

Added to the new "GPU Inference APIs" subsection under AI Agent Integration, since this is a distinct category — x402-payable compute resources specifically for agents that need inference without managing multiple provider APIs.