### PR TITLE
Add ATXP — x402-compatible agent identity and funding platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 ### Agent Frameworks
 
+- [ATXP](https://github.com/atxp-dev/atxp) - Agent identity and funding platform. One command — `npx atxp agent register` — gives an agent a USDC wallet on Base, an `@atxp.email` inbox, a phone number, and 100+ paid tools (web search, image/video generation, LLM gateway). x402-compatible; agents can pay x402 endpoints directly from their ATXP balance. $5 free credit, no KYC. ([Docs](https://docs.atxp.ai))
 - [NEAR AI](https://near.ai) - Cross-chain agent settlements.
 - [Phidata Agents](https://github.com/phidatahq/phidata) - Multi-modal agents with x402.
 - [Vault-0](https://github.com/0-Vault/Vault-0) - Encrypted secret vault, agent monitor, and x402 wallet for OpenClaw. Handles 402 detection, EIP-3009 signing, and policy-gated auto-settlement.


### PR DESCRIPTION
## What's being added

[ATXP](https://github.com/atxp-dev/atxp) — agent identity and funding platform.

Added under **🤖 AI Agent Integration > Agent Frameworks**.

## Why it belongs here

ATXP is x402-compatible: agents fund their ATXP wallet with USDC on Base, then call any x402-payable endpoint directly from that balance. It fills a gap that existing SDKs don't cover — the "cold start" problem where an agent needs funded identity before it can make any x402 payments.

One command gives an agent:
- USDC wallet on Base (x402-compatible)
- `@atxp.email` inbox
- Phone number (SMS + voice)
- 100+ paid tools via MCP (web search, image/video generation, LLM gateway)

```bash
npx atxp agent register
```

$5 free credit, no KYC, no human login required.

## Links

- GitHub: https://github.com/atxp-dev/atxp
- Docs: https://docs.atxp.ai