### PR TITLE
Add Arch Tools — 58-tool API platform with x402 payments + patent-pending agent auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Real companies using x402 in production with proven scale and transaction volume
 
 ### High-Volume Production Deployments
 
+- [Arch Tools](https://archtools.dev) - 58 production API tools for AI agents with x402 payments built in. Web scraping, AI generation, crypto data, OCR, browser automation, MCP compatible. Patent-pending agent auth. 15+ chains supported. ([GitHub](https://github.com/Deesmo/Arch-AI-Tools))
 - [AIsa](https://aisa.network) - Leading x402 payment processor with **10.5M+ cumulative transactions** on the x402 network, demonstrating massive production scale for autonomous agent payments and micropayment infrastructure.
 - [Bitget](https://www.bitget.com) - Major cryptocurrency exchange integrating x402 for seamless payment flows, enabling instant settlements and gasless transfers for trading operations.
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.


### PR DESCRIPTION
Adding Arch Tools to the Production Implementations section.

**Arch Tools** is the first API platform to wire x402 payments into every endpoint:

- 58 production tools: web scraping, AI generation (Claude/GPT/Grok/Gemini), crypto data, OCR, NLP, browser automation, email
- Every endpoint accepts x402 USDC payments on 15+ chains (Base, Ethereum, Solana, Polygon, Arbitrum, Avalanche, etc.)
- Patent-pending agent auth protocol (Application #64/008,145, March 2026)
- x402 service directory at archtools.dev/directory
- MCP server: npx @deesmo/arch-tools-mcp
- 100 free credits to test

This is a live production implementation with real payment settlement on Base.