### PR TITLE
Add x402 Gateway - Simple pay-per-use API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Full working examples and templates.
 ### API Examples
 
 - [SolSignal API](https://solsignal-api.onrender.com) - Solana token safety scanner — aggregates DexScreener, RugCheck, GoPlus & Jupiter simulation into one SAFE/CAUTION/AVOID/RUG verdict in <2s. 10 free scans/day, $0.01 USDC per call on Solana. [Source](https://github.com/cryptomotifs/solsignal-api)
-- [x402 Gateway](http://43.134.241.191:3456/) - Simple Node.js API gateway for AI agents. Weather ($0.01), crypto prices ($0.01), exchange rates ($0.005), news ($0.02). USDC on Polygon. No registration. [Source](https://github.com/863king/x402-gateway)
+- [x402 Gateway](https://zoning-amsterdam-ends-disposition.trycloudflare.com) - Simple Node.js API gateway for AI agents. Weather ($0.01), crypto prices ($0.01), exchange rates ($0.005), news ($0.02). USDC on Polygon. HTTPS via Cloudflare Tunnel. [Source](https://github.com/863king/x402-gateway)
 - [Alfred's Digital Bazaar](https://httpay.xyz) - ~100 x402-paywalled API endpoints built by an AI agent. Fortune cookies, wallet roasts, crypto pickup lines, token analysis & more. $0.10–$1.00 USDC per call on Base. No signup required. [Source](https://github.com/Alfredz0x/alfreds-digital-bazaar)
 - [Gotobi Calendar API](https://gotobi.hugen.tokyo) - Japanese FX gotobi date intelligence for AI trading agents. Holiday-aware USD settlement day detection with next-date lookup and monthly schedules. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-gotobi-api)
 - [Weather API](https://weather.hugen.tokyo) - Global weather data for AI agents. Real-time conditions and 7-day forecasts for any city worldwide. $0.001 USDC per call on Base. [Source](https://github.com/bartonguestier1725-collab/x402-weather-api)


### PR DESCRIPTION
## Add x402 Gateway

A simple Node.js x402 API gateway for AI agents.

### Details
- **Live:** http://43134.241.191:3456/
- **GitHub:** https://github.com/863king/x402-gateway
- **Network:** Polygon (USDC)
- **Pricing:** $0.005-$0.02 per call

### APIs
- Weather data (wttr.in)
- Crypto prices (CoinGecko)
- Exchange rates
- Crypto news

### Why
- Simple self-host solution
- No registration required
- Perfect for AI agents learning x402