### PR TITLE
Add Mercury402 to API Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Full working examples and templates.
 - REST API with Auth Pricing - SIWE + dynamic pricing.
 - [PortsideLabs Places API](https://portsidelabs-x402-places-536698811508.us-west1.run.app) - Google Places API v1 proxy with x402 pay-per-request access. Exposes place detail lookup and full-text search via USDC micropayments on Base mainnet and Solana mainnet. $0.001 USDC per call.
 - [PortsideLabs KoinChappie](https://portsidelabs-x402-koinchappie-536698811508.us-west1.run.app) - Crypto signals API with x402 pay-per-request. Returns bull and bear signals for the top 10 cryptocurrencies by market cap across 8 timeframes (1m–1D) using SMA(14). Single-coin lookup supports any CryptoCompare symbol. USDC micropayments on Base mainnet and Solana mainnet. $0.001 USDC per call. 
+- [Mercury402](https://mercury402.uk) - Pay-per-call U.S. Treasury and macro data API using x402. Agents access FRED indicators, yield curves, and GDP data with USDC micropayments on Base.
 
 ### Client Examples
 


### PR DESCRIPTION
Add Mercury402 — pay-per-call financial data API built on x402 protocol. 76 live endpoints covering FRED economic series, Treasury yields, forex rates, yield spreads, breakeven inflation, macro bundles, and recession probability. Live at https://mercury402.uk/