### PR TITLE
Add Hodler DeFi Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Projects building with or extending x402.
 - [Signet](https://signet.sebayaki.com) - Onchain spotlight ads on Base — AI agents pay USDC via x402 to post ads. First mainnet x402 transaction on Base. [CLI](https://github.com/h1-hunt/signet-client)
 - **[x402-api](https://x402-api.fly.dev)** — Pay-per-call DeFi & crypto data API. 8 endpoints: price feeds, whale tracking, gas tracker, DEX quotes, token scanner, yield scanner, funding rates, wallet profiler. USDC micropayments on Base. ERC-8004 Agent #18763.
 - [DeFi Intelligence API](https://defi.hugen.tokyo) — Unified DeFi security, bridging, and analytics API for AI agents. 26 endpoints across three backends: GoPlus Security (token/address/NFT security, rugpull detection, phishing, tx simulation), LI.FI (cross-chain bridge quotes, routes, gas prices), and DeFi Llama (protocol TVL, fees, token prices, stablecoin data, DEX volumes). $0.005–$0.01 USDC on Base. Discovery: [/.well-known/x402](https://defi.hugen.tokyo/.well-known/x402)
+- [Hodler DeFi Intelligence](https://x402.hodle.com.br) - Stablecoin monitoring, redeem arbitrage scanning, pegged pair opportunities, and cross-chain pair discovery across 10 EVM chains. 6 paid endpoints at $0.01 USDC each via xpay.sh facilitator on Base.
 
 ### Developer Tools
 


### PR DESCRIPTION
Adds Hodler DeFi Intelligence - real-time DeFi data for AI agents.

- 6 x402 endpoints ($0.01 USDC each on Base)
- Uses xpay.sh facilitator (non-custodial, zero-fee)
- 120+ stablecoins, arbitrage opportunities, cross-chain pair discovery
- Live at https://x402.hodle.com.br
- Agent catalog: https://x402.hodle.com.br/.well-known/agent-catalog.json