### PR TITLE
Add APIbase.pro to ecosystem — 263 tools, 74 providers, x402 payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Projects building with or extending x402.
 
 ### Tools & Services
 
+- [APIbase.pro](https://apibase.pro) — MCP gateway with 263+ tools from 74 providers, x402 USDC micropayments on Base. Open source. ([GitHub](https://github.com/whiteknightonhorse/APIbase))
 - [Satring](https://satring.com) - Curated L402 + x402 API directory with human ratings, health monitoring, and MCP server for AI agent discovery. Dual-protocol support (Lightning + USDC on Base). ([GitHub](https://github.com/toadlyBroodle/satring)) | ([MCP](https://pypi.org/project/satring-mcp/))
 - [Pylon](https://pylonapi.com) — x402-payable utility API gateway for AI agents. 20 capabilities (web extraction, search, translation, code execution, image generation, and more) on Base mainnet. MCP server (`npx @pylonapi/mcp`), agent reputation network, and gateway orchestration. USDC on Base. ([GitHub](https://github.com/pylon-apis/pylon-mcp))
 - [x402 Bazaar](https://x402bazaar.org) - Decentralized API marketplace with 69 native x402-payable endpoints (web search, DALL-E 3, weather, crypto, translation, code execution, and more). Multi-chain USDC on Base and SKALE. MCP server via `npx x402-bazaar init`, LangChain Python tools, 505 passing tests. ([GitHub](https://github.com/Wintyx57/x402-backend))


### PR DESCRIPTION
Description:
Adding APIbase.pro — the largest x402-enabled MCP server in the ecosystem.

- **263 tools** across 74 providers (travel, finance, maps, entertainment, health, education, legal, and more)
- **x402 USDC micropayments** on Base mainnet for all paid tool calls
- **MCP endpoint**: https://apibase.pro/mcp
- **Open source**: https://github.com/whiteknightonhorse/APIbase
- **Live dashboard**: https://apibase.pro/dashboard

Listed on Smithery, Glama, and Official MCP Registry.