### PR TITLE
Add monapi: one-line API monetization SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Server-side integrations for accepting x402 payments.
 
 ### Node.js/TypeScript
 
+**Multi-Framework**
+- [monapi](https://monapi.dev) - One-line API monetization SDK. Wraps x402 setup into a single function call. Express, Next.js, and MCP support. Per-route pricing, Base/Arbitrum/Polygon, gas-free agent payments via EIP-3009. ([npm](https://www.npmjs.com/package/@monapi/sdk)) ([GitHub](https://github.com/DenisTheM/monapi))
+
 **Next.js**
 - [x402-next](https://www.npmjs.com/package/x402-next) - App Router middleware.
 - [Next.js route protection](https://github.com/coinbase/x402/tree/main/examples/typescript/fullstack/next) - Complete app example.


### PR DESCRIPTION
Adds [monapi](https://monapi.dev) to the Server Frameworks & Middleware section.

monapi wraps x402 into a single function call for Express, Next.js, and MCP:

```typescript
import { monapi } from "@monapi/sdk";
app.use(monapi({ wallet: "0x...", price: 0.01 }));
```

- npm: [@monapi/sdk](https://www.npmjs.com/package/@monapi/sdk)
- GitHub: [DenisTheM/monapi](https://github.com/DenisTheM/monapi)
- Website: [monapi.dev](https://monapi.dev)