### PR TITLE
Add CardZero — AI agent payment wallet with x402 buyer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [NEAR AI](https://near.ai) - Cross-chain agent settlements.
 - [Phidata Agents](https://github.com/phidatahq/phidata) - Multi-modal agents with x402.
 - [Vault-0](https://github.com/0-Vault/Vault-0) - Encrypted secret vault, agent monitor, and x402 wallet for OpenClaw. Handles 402 detection, EIP-3009 signing, and policy-gated auto-settlement.
+- [CardZero](https://cardzero.ai) - Payment wallet for AI agents on Base L2. Each agent gets an ERC-4337 smart contract wallet with owner-controlled spending rules (per-tx limits, daily caps, whitelist, freeze). x402 buyer support via `POST /v1/x402/pay`. [ClawHub](https://clawhub.ai/mrocker/cardzero) | [GitHub](https://github.com/mrocker/CardZero) | [API Docs](https://cardzero.ai/docs/api)
 
 ### Agent-to-Agent (A2A)
 


### PR DESCRIPTION
## What is CardZero?

CardZero is a payment wallet built specifically for AI agents on Base L2. Each agent gets its own ERC-4337 smart contract wallet, funded with USDC, with spending rules set by a human owner via a web dashboard.

## x402 Integration

CardZero implements x402 buyer-side support:
- `POST /v1/x402/pay` — Agent sends payment when encountering HTTP 402
- Returns `paymentHeader` for the agent to retry the original request with `X-PAYMENT` header
- Supports Base Mainnet (`eip155:8453`) with USDC

## Key Features
- **Owner-Agent trust model**: Human sets spending rules, agent pays autonomously within limits
- **ERC-4337 smart contract wallets**: Self-owned, UUPS upgradeable, no third-party dependency
- **Multi-platform**: OpenClaw SKILL, Claude Code, ChatGPT, Cursor plugins
- **Production**: Live on Base Mainnet at [cardzero.ai](https://cardzero.ai)

## Links
- Dashboard: https://cardzero.ai
- ClawHub SKILL: https://clawhub.ai/mrocker/cardzero
- GitHub: https://github.com/mrocker/CardZero