### PR TITLE
Add PROWL — 47 x402-gated data feeds for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [PayCrow](https://github.com/michu5696/paycrow) - Escrow protection for autonomous agent payments. Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution on Base. 10 MCP tools including safe_pay (trust-informed smart escrow) and trust_gate (go/no-go decision before payment). ([npm](https://www.npmjs.com/package/paycrow))
 - [Recall Kitchen](https://recallkitchen.com/docs/#mcp) - MCP server for searching food/product/vehicle recalls. Accepts x402 payments, no account required, $0.025 USDC on Base per request. [Examples](https://github.com/Recall-Kitchen/rk-mcp/tree/master/examples/go)
 - [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Supports x402 pay-per-use for profile views ($0.05) and job offers ($0.25) in USDC on Base. Also available as an [MCP server](https://github.com/human-pages-ai/humanpages) with 31 tools.
+- [PROWL](https://prowldata.dev) - 47 real-world data feeds (prediction markets, economics, weather, geopolitics, narrative, crypto) for AI agents, paid per-call via x402. Includes MCP server for Claude and compatible agents.
 
 ### Agent Frameworks
 


### PR DESCRIPTION
Adds [PROWL](https://prowldata.dev) to the list.

- 47 feeds across 6 domains (markets, macro, weather, narrative, geo, crypto)
- x402 micropayments via USDC on Base ($0.001–$0.05 per call)
- MCP server at prowldata.dev/mcp
- OpenAPI spec, llms.txt, and standard discovery files
- Live and processing requests

🤖🤖🤖