### PR TITLE
Add Revettr - counterparty risk scoring for x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - OpSpawn A2A x402 Gateway - Multi-chain A2A gateway with x402 payments.
   - Google A2A protocol with x402 payment integration
   - Multi-chain support (Base, SKALE, Arbitrum)
+- [Revettr](https://revettr.com) - Counterparty risk scoring API for x402 agentic commerce. Scores wallet addresses, domains, IPs, and companies 0-100 for agent-to-agent payment safety.
 
 
 ## 🔨 Tools & Utilities


### PR DESCRIPTION
## Add Revettr

**What:** Adding [Revettr](https://revettr.com) to the AI Agent Integration > Agent-to-Agent (A2A) section. Revettr is a counterparty risk scoring API purpose-built for x402 agentic commerce.

**Why:** As agent-to-agent payments scale, agents need a way to evaluate counterparty risk before committing funds. Revettr scores wallet addresses, domains, IPs, and companies on a 0-100 scale so agents can make trust-informed payment decisions autonomously. It is x402-native with Bazaar discovery support, making it directly relevant to the A2A commerce ecosystem.

**Quality Checklist:**
- [x] Resource is actively maintained
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** AI Agent Integration > Agent-to-Agent (A2A)