### PR TITLE
Add x402 Wallet for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [PayCrow](https://github.com/michu5696/paycrow) - Escrow protection for autonomous agent payments. Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution on Base. 10 MCP tools including safe_pay (trust-informed smart escrow) and trust_gate (go/no-go decision before payment). ([npm](https://www.npmjs.com/package/paycrow))
 - [Recall Kitchen](https://recallkitchen.com/docs/#mcp) - MCP server for searching food/product/vehicle recalls. Accepts x402 payments, no account required, $0.025 USDC on Base per request. [Examples](https://github.com/Recall-Kitchen/rk-mcp/tree/master/examples/go)
 - [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Supports x402 pay-per-use for profile views ($0.05) and job offers ($0.25) in USDC on Base. Also available as an [MCP server](https://github.com/human-pages-ai/humanpages) with 31 tools.
+- [x402 Wallet for Claude Desktop](https://github.com/402md/x402-wallet-for-claude-desktop) - Native Claude Desktop extension (.mcpb one-click install) with USDC wallet on Stellar and Base. Three tools: check_balance, pay, and x402_fetch with automatic 402 payment handling. Configurable budget limits per call and per day.
 
 ### Agent Frameworks
 


### PR DESCRIPTION
## What
Adds x402 Wallet for Claude Desktop to the MCP Integration section.

## Why
It's a native Claude Desktop extension (.mcpb) that gives Claude a USDC wallet with multi-chain support (Stellar + Base/Coinbase). Key differentiators:

- **One-click install** — .mcpb bundle, double-click to configure
- **Stellar + Base** — supports both networks for USDC payments
- **Automatic x402 flow** — x402_fetch handles 402 → sign → retry in a single call
- **Budget safety** — configurable per-call and daily USDC spending limits
- **3 focused tools** — check_balance, pay, x402_fetch

## Quality checklist
- [x] Actively maintained
- [x] Clear documentation (README with full API reference)
- [x] MIT licensed
- [x] x402-specific
- [x] All links verified