### PR TITLE
Add Agent Forensics to Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Development tools and utilities for x402.
 
 - [ScoutScore](https://scoutscore.ai) - Trust scoring infrastructure for x402 services. Monitors 1,700+ services with continuous health checks and fidelity probes using a 4-pillar model (Contract Clarity, Availability, Response Fidelity, Identity & Safety). [API Docs](https://scoutscore.ai/docs) · [npm SDK](https://www.npmjs.com/package/@scoutscore/sdk) · [MCP Server](https://www.npmjs.com/package/@scoutscore/mcp-server)
 - [Paybound](https://github.com/pando-b/paybound) - Open-source governance proxy for x402 agent payments. Per-agent budgets, circuit breakers, and SQLite audit trail.
+- [Agent Forensics](https://www.npmjs.com/package/agent-forensics) - Agent cost observability for Claude Code. Analyzes JSONL session logs to show per-model cost breakdown, cache efficiency, waste patterns (model misallocation, debug loops, sub-agent sprawl), and estimated savings. Free CLI: `npx agent-forensics analyze`. x402 API: $5 basic / $15 full tier on Base. ([Live](https://api.agentsconsultants.com))
 
 ## 🧪 Testing & Development
 


### PR DESCRIPTION
Adds [Agent Forensics](https://www.npmjs.com/package/agent-forensics) to the Monitoring & Analytics section.

**What it does:** Agent cost observability for Claude Code — analyzes JSONL session logs to show per-model cost breakdown, cache efficiency, waste patterns, and estimated savings.

- Free CLI: `npx agent-forensics analyze`
- x402 API at https://api.agentsconsultants.com: $5 basic / $15 full analysis (USDC on Base)
- MIT-licensed, runs locally, no data leaves the user's machine

Fits naturally in Monitoring & Analytics alongside Sentinel and ScoutScore.