### PR TITLE
Add x402-pay Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Official and community implementations of the x402 protocol.
 
 - [ag402](https://github.com/AetherCore-Dev/ag402) ⭐ **Community** - Payment layer for AI agents using x402. Wrap any API or MCP server with a USDC paywall (`ag402 serve`), or let agents auto-pay (`ag402 run`). Solana USDC, ~0.5s settlement, non-custodial, 648+ tests. [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/ag402-mcp)
 
+- [x402-pay](https://pypi.org/project/x402-pay/) - Call any x402 API with one API key. Routes requests through a broker that handles on-chain payment. httpx-based, optional wallet mode for direct payments. ([GitHub](https://github.com/bartonguestier1725-collab/x402-pay))
+
 ### Rust
 
 - [x402-rs](https://github.com/x402-rs/x402-rs) ⭐ **Community** - Production-grade Rust implementation.


### PR DESCRIPTION
Adds [x402-pay](https://pypi.org/project/x402-pay/) to the Python Client Libraries section.

- httpx-based client that routes requests through a broker
- API key authentication, no per-API wallet integration needed
- Optional wallet mode for direct on-chain payments
- Published on PyPI: `pip install x402-pay`