### PR TITLE
Add MERX - First x402 facilitator for TRON

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Payment verification and settlement services.
 - [Cloudflare x402](https://blog.cloudflare.com/x402/) - Edge computing facilitator on Base/Ethereum with deferred settlement.
 - [BNB Chain Pieverse](https://twitter.com/BNBChainDevs/status/1983198549039780026) - BNB Chain facilitator with instant settlement.
 - [AsterPay](https://asterpay.io) - European x402 Facilitator with EUR off-ramp via SEPA Instant. MiCA compliant, ERC-8004 ready, ElizaOS plugin. First European-focused x402 infrastructure.
+- [MERX x402 for TRON](https://x402.merx.exchange) - First TRON facilitator. Supports USDT, USDC, USDD on TRON mainnet. Sub-3-second confirmation for micropayments. [Express middleware](https://npmjs.com/package/merx-x402), [documentation](https://github.com/Hovsteder/x402-tron).
 - [Primev FastRPC](https://facilitator.primev.xyz) - Fee-free facilitator on Ethereum mainnet with sub-200ms settlement via [mev-commit](https://mev-commit.xyz) preconfirmations. ERC-8004 registered (Agent #23175).
 
 ### Self-Hosted Facilitators


### PR DESCRIPTION
## MERX - First x402 Facilitator for TRON

**URL:** https://x402.merx.exchange
**Networks:** TRON
**Assets:** USDT, USDC, USDD
**Middleware:** [merx-x402](https://npmjs.com/package/merx-x402) (Express)
**Docs:** [github.com/Hovsteder/x402-tron](https://github.com/Hovsteder/x402-tron)
**Discovery:** https://x402.merx.exchange/.well-known/x402

Mainnet verified: https://tronscan.org/#/transaction/7a92e577b3f44faa97204983af3e74a71cac5a88732af54fca9c2464d9285ca4

TRON carries $85B+ USDT (63% of global supply). This is the first x402 facilitator bringing TRON to the x402 ecosystem.