### PR TITLE
Add DevDrops — 22 pay-per-query data APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Real companies using x402 in production with proven scale and transaction volume
 ### Data & Social APIs
 
 - [Xquik](https://xquik.com) - Real-time X (Twitter) data API with 7 MPP/x402 pay-per-use endpoints — tweet lookup, tweet search, user lookup, follower check, article extraction, media download, and trends. No accounts or subscriptions required. ([GitHub](https://github.com/Xquik-dev/tweetclaw)) ([npm](https://www.npmjs.com/package/@xquik/tweetclaw)) ([MCP Server](https://xquik.com/mcp))
+- [DevDrops](https://devdrops.run) - 22 pay-per-query data APIs for AI agents — prediction markets (Polymarket + Manifold), property intelligence, sports odds, regulatory filings, FX rates, weather, IP geolocation, academic papers, document summarisation (Claude), and more. $0.001–$0.10 USDC per query on Base. No API keys or subscriptions. ([OpenAPI](https://api.devdrops.run/openapi.json)) ([Catalog](https://api.devdrops.run/catalog))
 
 ### Enterprise Adoption
 


### PR DESCRIPTION
## What is DevDrops?

[DevDrops](https://devdrops.run) is a suite of 22 pay-per-query data APIs built natively on x402, running on Cloudflare Workers (Base mainnet).

AI agents send a standard HTTP request, receive HTTP 402, pay USDC on Base, and get structured JSON — no API keys, no accounts, no subscriptions.

**Endpoints include:**
- Prediction markets (Polymarket + Manifold)
- Property intelligence & address reports (UK)
- Sports betting odds (cross-bookmaker)
- Regulatory filings (SEC EDGAR + Companies House)
- FX rates, weather, IP geolocation, historical events
- Academic papers (OpenAlex + Semantic Scholar)
- AI-enhanced: document summarisation, research briefs, news sentiment (Claude)

**Pricing:** $0.001–$0.10 USDC per query  
**Network:** Base mainnet (`eip155:8453`)  
**OpenAPI spec:** https://api.devdrops.run/openapi.json  
**Machine-readable catalog:** https://api.devdrops.run/catalog

Added to the **Data & Social APIs** section under Production Implementations.