### PR TITLE
Add ZKProofport MCP (ZK identity proofs paid via x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [JubJub MCP](https://api.jubjubapp.com/v2/mcp) - 65-tool MCP server for media publishing, cross-platform analytics, and automated on-chain royalty splits. Agents publish content, track performance, and surface claimable USDC balances autonomously. api.jubjubapp.com/v2/mcp
 - [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Supports x402 pay-per-use for profile views ($0.05) and job offers ($0.25) in USDC on Base. Also available as an [MCP server](https://github.com/human-pages-ai/humanpages) with 31 tools.
 - [TweetClaw](https://xquik.com/mcp) - OpenClaw/MCP plugin for Xquik's real-time X (Twitter) data. 7 pay-per-use endpoints via MPP/x402 — tweet lookup, search, user lookup, follower check, article, media download, and trends. ([GitHub](https://github.com/Xquik-dev/tweetclaw)) ([npm](https://www.npmjs.com/package/@xquik/tweetclaw))
+- [ZKProofport MCP](https://github.com/zkproofport/proofport-ai) - Zero-knowledge identity proof MCP server. Generates Coinbase KYC, Country, Google OIDC, Workspace, and MS 365 proofs without revealing personal data. AWS Nitro Enclave TEE proving, ERC-8004 registered (token ID 25331). x402 USDC payments on Base. NPM: `@zkproofport-ai/mcp`. Reference application [OpenStoa](https://github.com/zkproofport/openstoa) won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026).
 
 ### Agent Frameworks
 


### PR DESCRIPTION
Adds ZKProofport MCP to the **AI Agent Integration → Model Context Protocol (MCP)** section.

ZKProofport is the first x402-paid zero-knowledge proof generation service. AI agents can prove identity claims without exposing personal data:
- **Coinbase KYC** verification
- **Country residency** proofs
- **Google OIDC** login (any domain)
- **Google Workspace** organizational domain
- **Microsoft 365** corporate domain

**Architecture:**
- Server-side proving in AWS Nitro Enclave TEE
- Noir circuits (Aztec) for the ZK layer
- ERC-8004 registered (token ID 25331 on Base Mainnet)
- A2A compliant agent card
- Open source MIT

**Reference application**: [OpenStoa](https://github.com/zkproofport/openstoa) — ZK-gated community where humans and AI agents coexist. Won 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects, 1500+ builders).

NPM: `@zkproofport-ai/mcp`