### PR TITLE
Add PayAPI Market — 10 x402-powered APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Real companies using x402 in production with proven scale and transaction volume
 ### High-Volume Production Deployments
 
 - [Arch Tools](https://archtools.dev) - 58 production API tools for AI agents with x402 payments built in. Web scraping, AI generation, crypto data, OCR, browser automation, MCP compatible. Patent-pending agent auth. 15+ chains supported. ([GitHub](https://github.com/Deesmo/Arch-AI-Tools))
+- [PayAPI Market](https://payapi.market) - First marketplace for x402-powered APIs. 10 APIs, 65 endpoints: UK property data, email verification, company enrichment, postcode lookup, currency/crypto rates, screenshots, DNS intelligence, web scraping, IP geolocation, QR codes. $0.001–$0.01 USDC on Base per request. MCP server discovery. ([GitHub](https://github.com/chetparker/x402-marketplace))
 - [AIsa](https://aisa.network) - Leading x402 payment processor with **10.5M+ cumulative transactions** on the x402 network, demonstrating massive production scale for autonomous agent payments and micropayment infrastructure.
 - [Bitget](https://www.bitget.com) - Major cryptocurrency exchange integrating x402 for seamless payment flows, enabling instant settlements and gasless transfers for trading operations.
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.


### PR DESCRIPTION
## Summary

Adds [PayAPI Market](https://payapi.market) to the Production Implementations section.

PayAPI Market is a marketplace for x402-powered APIs designed for AI agents. Currently live with 10 APIs and 65 endpoints:

- UK property/government data (24 endpoints)
- Email verification (syntax, MX, SMTP, disposable detection)
- Company enrichment (Companies House + domain intelligence)
- UK postcode/address lookup
- Currency exchange rates + crypto prices
- Website screenshots and PDF capture
- DNS records, WHOIS, SSL certs, subdomain discovery
- Web scraping and content extraction
- IP geolocation
- QR code generation and decoding

All endpoints accept x402 per-request USDC payments on Base ($0.001–$0.01). Every API includes an MCP server for agent discovery.

- **Live:** https://payapi.market
- **GitHub:** https://github.com/chetparker/x402-marketplace