### PR TITLE
Add KaelAi to Security & Audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,8 @@ Comprehensive guides for migrating from traditional payment systems to x402.
 
 ## 🔒 Security & Audits
 
+*[KaelAi] (https://kaelai.io) - Wallet trust scoring API for the agentic economy. Scores wallets 0-100 across 10 chains with behavioural analysis. Built for x402 servers to vet incoming and outgoing payment wallets before serving or initiating requests. 
+
 - [stripe-mcps](https://www.npmjs.com/package/stripe-mcps) - Trust verification + AML sanctions screening before Stripe/x402 payments. Agent identity (ECDSA), 75K+ sanctions entries (UK HMT + OFAC SDN), behavioural spend limits. OWASP MCP Security Cheat Sheet aligned. ([GitHub](https://github.com/razashariff/stripe-mcps))
 Security resources and best practices for x402 implementations.
 


### PR DESCRIPTION
KaelAi is a wallet trust scoring API built for the agentic economy. 

It scores wallets 0–100 across 10 chains (BTC, ETH, SOL, Base, Polygon, BSC, Arbitrum, AVAX, TAO, and HYPE) with behavioral analysis, 
bond-style grades (AAA–CCC), risk flags, and plain-English reasoning.

Designed specifically for x402 servers to vet incoming and outgoing payment wallets before serving or initiating requests - the trust 
layer that sits alongside the payment layer.

Free tier available at kaelai.io
