### PR TITLE
Add @moltrust/x402 — trust score middleware for x402 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Server-side integrations for accepting x402 payments.
 
 ### Node.js/TypeScript
 
+**Express / Hono**
+- [@moltrust/x402](https://www.npmjs.com/package/@moltrust/x402) - Trust score middleware for x402 endpoints. One line: `app.use(requireScore({ minScore: 60 }))`. Extracts paying wallet from X-Payment header, looks up MolTrust trust score, blocks agents below threshold with 403 + registration link. Zero dependencies. ([npm](https://www.npmjs.com/package/@moltrust/x402)) ([GitHub](https://github.com/MoltyCel/moltrust-x402))
+
 **Next.js**
 - [x402-next](https://www.npmjs.com/package/x402-next) - App Router middleware.
 - [Next.js route protection](https://github.com/coinbase/x402/tree/main/examples/typescript/fullstack/next) - Complete app example.


### PR DESCRIPTION
Adds [@moltrust/x402](https://www.npmjs.com/package/@moltrust/x402) to the Server Frameworks & Middleware section.

**What it does:**
- Extracts paying wallet from x402 `X-Payment` header
- Looks up MolTrust trust score for that wallet (5-min cache)
- Allows or denies based on configurable `minScore` threshold
- Returns 403 + `moltrust.ch/wallet/{address}` profile link if denied

**Usage:**
```js
const { requireScore } = require('@moltrust/x402');
app.use(requireScore({ minScore: 60 }));
```

Zero dependencies. MIT license. Express and Hono. Live on npm since March 2026.

- npm: https://www.npmjs.com/package/@moltrust/x402
- GitHub: https://github.com/MoltyCel/moltrust-x402
- MolTrust: https://moltrust.ch