### PR TITLE
Add AgentData API to Data & Social APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Real companies using x402 in production with proven scale and transaction volume
 ### Data & Social APIs
 
 - [Xquik](https://xquik.com) - Real-time X (Twitter) data API with 7 MPP/x402 pay-per-use endpoints — tweet lookup, tweet search, user lookup, follower check, article extraction, media download, and trends. No accounts or subscriptions required. ([GitHub](https://github.com/Xquik-dev/tweetclaw)) ([npm](https://www.npmjs.com/package/@xquik/tweetclaw)) ([MCP Server](https://xquik.com/mcp))
+- [AgentData API](https://agentdata-api.com) - Real-time crypto market data for AI agents. 16 pay-per-request endpoints on Base Mainnet: prices, funding rates, volatility, liquidation levels, DeFi yields, cross-exchange arbitrage, technical indicators (RSI/MACD/BB/ATR), support/resistance, sentiment, stablecoin health, and historical OHLCV. Self-hosted facilitator, no accounts required. Supports x402 v2 with Bazaar discovery extension. ([Discovery](https://agentdata-api.com/discovery)) ([OpenAPI](https://agentdata-api.com/openapi.json))
 
 ### Enterprise Adoption
 


### PR DESCRIPTION
## Summary

Adds [AgentData API](https://agentdata-api.com) — a new production x402 service on Base Mainnet — to the Data & Social APIs section.

## What is AgentData API?

A pay-per-request crypto market data API built specifically for AI agents. **16 endpoints** covering:

**Market Data** — prices, funding rates, volatility, liquidation levels, correlation, market overview
**On-Chain** — multi-chain gas prices, Base Mainnet activity, DefiLlama yields
**Arbitrage** — cross-exchange opportunities, DEX vs CEX spreads
**Technical Analysis** — RSI, MACD, Bollinger Bands, ATR, support/resistance
**Sentiment & Macro** — Fear & Greed composite, stablecoin peg monitoring
**Historical** — OHLCV candles for backtesting

## Technical Details

- Network: Base Mainnet (eip155:8453)
- Payment: USDC via x402 v2 protocol
- Facilitator: Self-hosted (no CDP dependency)
- Prices: $0.001 - $0.005 per request
- Discovery: `/discovery`, `/openapi.json`, `/llms.txt`, `/agent.json`
- Bazaar extension support for agentcash/x402scan compatibility

Already listed on x402scan.com. Live end-to-end payment test verified on Base Mainnet (TX: `0x4859b6e35bcecc0f99edef9d3a14ed51183b1c04078bd6fe046f0d5ca6a969bd`).

## Checklist

- [x] Added to the correct section (Data & Social APIs under Production Implementations)
- [x] Format matches existing entries
- [x] Service is live and accepting payments