### PR TITLE
Add SelfHeal — x402 API error healing proxy for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Real-world use cases and implementation patterns. The x402 protocol has seen **1
 - [MAXIA](https://maxiaworld.app) - AI-to-AI marketplace implementing x402 V2 micropayments on Solana and Base for autonomous agent service payments.
 
 Enable AI agents to make autonomous payments.
+- [SelfHeal](https://selfheal.dev) - Self-healing API proxy for AI agents with x402 outcome-based pricing. Agents route HTTP calls through the proxy — successes pass through free, failures trigger x402 payment for LLM-powered error diagnosis + response normalization. $0.001-$0.005 USDC on Base, charged only on successful heal. Published SDKs on npm and PyPI with native x402 support. ([GitHub](https://github.com/carsonlabs/graceful-fail)) ([npm](https://www.npmjs.com/package/graceful-fail)) ([PyPI](https://pypi.org/project/graceful-fail/))
 - [Strale MCP Server](https://api.strale.io/mcp) - 250+ business data and compliance tools for AI agents via MCP. IBAN validation, VAT format checks, sanctions screening, company lookups, SSL certificate checks, domain reputation, and more. Each capability independently tested with quality scores. x402 USDC micropayments on Base. Also available as REST API.
 
 ### GPU Inference APIs


### PR DESCRIPTION
Adding [SelfHeal](https://selfheal.dev) to the AI Agent Integration section.

SelfHeal is a self-healing API proxy where AI agents pay via x402 only when errors are successfully diagnosed:
- Successes pass through free ($0)
- Failures: $0.001-$0.005 USDC on Base, outcome-based (only charged on successful heal)
- Gasless for payers (EIP-3009)
- Published SDKs on npm (`graceful-fail`) and PyPI (`graceful-fail`) with native x402 support
- First settlement TX: https://sepolia.basescan.org/tx/0xbf023f9c7d1587967adca9ddf4e2a628998cee130860d244c436c6e87385029a
- Open source: https://github.com/carsonlabs/graceful-fail