### PR TITLE
Add ALTER MCP — identity infrastructure with x402 Identity Income

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - x402 MCP Server - Claude Desktop ready server.
 - [MCP Server Setup Guide](https://docs.cdp.coinbase.com/x402/mcp-server) - Complete installation instructions.
 - Embedded Wallet MCP - Electron-based wallet for MCP.
+- [ALTER MCP](https://mcp.truealter.com/api/v1/mcp) - Identity infrastructure MCP for the AI economy. Agents query verified human identity via a 33-trait psychometric engine: belonging probability, trait alignment, and Ed25519-signed identity vectors. Identity Income earned via x402 USDC — agents pay $0.01/query, identity holders earn per verified query. 16 tools free (10 req/min). SDK: `@truealter/sdk`. ([Docs](https://truealter.com)) ([SDK](https://github.com/true-alter/alter-identity))
 - [MaximumSats MCP](https://github.com/joelklabo/maximumsats-mcp) - Lightning-native MCP tools with L402 micropayments and Nostr Web-of-Trust scoring APIs.
 - [Apollo Intelligence MCP Server](https://www.npmjs.com/package/@apollo_ai/mcp-proxy) - 26-tool MCP server covering intelligence feeds, crypto, OSINT, DeFi, proxy, and search. `npx @apollo_ai/mcp-proxy`. ([GitHub](https://github.com/bnmbnmai/mcp-proxy))
 - [Pylon MCP Server](https://www.npmjs.com/package/@pylonapi/mcp) - 20-tool MCP server for utility APIs: web extraction, search, translation, code execution, image generation, email, and more. `npx @pylonapi/mcp`. ([GitHub](https://github.com/pylon-apis/pylon-mcp))


### PR DESCRIPTION
## What

Adds ALTER to the Model Context Protocol (MCP) section under AI Agent Integration.

## Entry

```
- [ALTER MCP](https://mcp.truealter.com/api/v1/mcp) - Identity infrastructure MCP for the AI economy. Agents query verified human identity via a 33-trait psychometric engine: belonging probability, trait alignment, and Ed25519-signed identity vectors. Identity Income earned via x402 USDC — agents pay $0.01/query, identity holders earn per verified query. 16 tools free (10 req/min). SDK: `@truealter/sdk`. ([Docs](https://truealter.com)) ([SDK](https://github.com/true-alter/alter-identity))
```

## Why this list

ALTER uses x402 for "Identity Income" — a novel pattern where AI agents pay for identity queries via x402 USDC micropayments, and the identity holder earns per verified query. This is a direct x402 use case within the MCP ecosystem, making it a strong fit for the AI Agent Integration → MCP subsection.

## Checklist

- [x] Active MCP endpoint at `mcp.truealter.com/api/v1/mcp`
- [x] x402 USDC payments (Identity Income)
- [x] SDK (`@truealter/sdk`) is public Apache-2.0
- [x] Format matches existing MCP section entries