### PR TITLE
Add Radius Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Real companies using x402 in production with proven scale and transaction volume
 | Ethereum      | Production  | Cloudflare                 | Deferred        | Enterprise DApps          |
 | Solana        | Production  | Community                  | Instant (<1s)   | High-frequency trading    |
 | BNB Chain     | Production  | Pieverse                   | Instant (2s)    | Gaming, NFTs              |
+| Radius        | Production  | Community                  | Instant (<1s)   | Micropayments             |
 
 ### Data & Social APIs
 


### PR DESCRIPTION
## Add Radius Network

**What:** Add Radius Network to the Multi-Chain Production Support table.

**Why:** Radius Network mainnet launched March 5, 2026 with sub-second finality (~500ms) and sub-penny transaction fees (~$0.0001). x402 settlement infrastructure is deployed on Radius — Permit2 and x402ExactPermit2Proxy at canonical CREATE2 addresses. EVM-compatible, works with existing x402 SDKs out of the box.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Production Implementations > Multi-Chain Production Support