### PR TITLE
Add cipher-gas-oracle to API Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Full working examples and templates.
 - [Product Reputation API](https://github.com/andichen0420/x402-reputation-api) — AI-powered product reputation intelligence from Reddit, HN & YouTube. Pay $0.03-$0.08 USDC per query for structured scores, dimensional analysis, and competitor comparisons. ([Live](https://x402-reputation-api-production.up.railway.app)) ([x402scan](https://www.x402scan.com/server/8ae848b3-ea71-4b2a-8ea1-fa6bec508ca5))
 - [x402engine](https://x402engine.app) - Pay-per-call API gateway with 74 endpoints: 44 LLMs, image/video generation, crypto data, web search, code execution, TTS, travel, and IPFS. Multi-chain: USDC on Base, USDm on MegaETH, USDC on Solana. Discovery: [/.well-known/x402.json](https://x402engine.app/.well-known/x402.json) | [/.well-known/agent.json](https://x402engine.app/.well-known/agent.json). ([GitHub](https://github.com/agentc22/x402-engine)) | ([MCP](https://www.npmjs.com/package/x402engine-mcp))
 - [Trading Intelligence API](https://api.signalfuse.co) — Directional crypto trading signals fusing social sentiment, macro regime, and market structure. $0.001–$0.050 USDC per call on Base. 25 free credits per wallet. [Landing](https://signalfuse.co)
+- [cipher-gas-oracle](https://cipher-gas-oracle.vercel.app) - x402-gated multi-chain gas oracle. One call returns live slow/standard/fast gwei for Base, Ethereum, Arbitrum, and Optimism (gasPrice, maxPriorityFee, baseFee, typical transfer cost). $0.005 USDC/Base per call.
 
 ### Client Examples
 


### PR DESCRIPTION
Adding one new entry for a pay-per-call multi-chain gas oracle endpoint, live and verified:

**Example Applications > API Examples**
- cipher-gas-oracle - https://cipher-gas-oracle.vercel.app - x402-gated aggregation of live `eth_gasPrice`, `eth_maxPriorityFeePerGas`, and `baseFeePerGas` from Base, Ethereum, Arbitrum, and Optimism public RPCs. GET `/api/gas/quote` (optional `?chains=base,arbitrum`) returns a normalized quote per chain with slow/standard/fast gwei estimates and a typical 21000-gas transfer cost. $0.005 USDC/Base per call.

Use case: Agents routing transactions across multiple L2s want a single consolidated gas reading to pick the cheapest chain/time. Pay once, get all four chains typed and normalized — no per-provider RPC keys to manage.

Verified:
- Unpaid: `curl -i https://cipher-gas-oracle.vercel.app/api/gas/quote` -> HTTP 402 + valid x402 v2 accept-list JSON.
- Paid stub: `curl -H 'X-PAYMENT: test' 'https://cipher-gas-oracle.vercel.app/api/gas/quote?chains=base,arbitrum'` -> HTTP 200 + live quotes (Base 0.006 gwei, Arbitrum 0.02 gwei at time of ship).

Settles to `0xa0630fAD18C732e94D56d2D5F630963eb8fB9640` on Base (USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`). Next.js 16 on Vercel Hobby, no paid upstream API key (Alchemy used opportunistically for Ethereum if a key is present, public Cloudflare RPC otherwise).

Happy to reformat or drop if it doesn't fit the scope.
