### PR TITLE
Add HYDRA Regulatory Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,3 +846,5 @@ Looking for more awesome lists?
 </p>
 
 - Agentic Signal — paid BTC/ETH DCA signal API (x402 USDC on Base) + signed responses + proof/backtests. Docs: https://signal.agenticsignal.dev/docs
+
+- [HYDRA Regulatory Intelligence](https://hydra-api-nlnj.onrender.com) - Real-time regulatory risk scoring, FOMC signals, and prediction market data. 22 paid endpoints via x402. ([GitHub](https://github.com/OGCryptoKitty/hydra-arm3))


### PR DESCRIPTION
HYDRA: 22 x402-paid regulatory intelligence endpoints on Base L2.
SEC/CFTC/Fed/FinCEN monitoring, prediction market signals, FOMC data.
Live: https://hydra-api-nlnj.onrender.com
x402 Manifest: https://hydra-api-nlnj.onrender.com/.well-known/x402.json
