### PR TITLE
Add Satoshi Facilitator

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Payment verification and settlement services.
 - [BNB Chain Pieverse](https://twitter.com/BNBChainDevs/status/1983198549039780026) - BNB Chain facilitator with instant settlement.
 - [AsterPay](https://asterpay.io) - European x402 Facilitator with EUR off-ramp via SEPA Instant. MiCA compliant, ERC-8004 ready, ElizaOS plugin. First European-focused x402 infrastructure.
 - [Primev FastRPC](https://facilitator.primev.xyz) - Fee-free facilitator on Ethereum mainnet with sub-200ms settlement via [mev-commit](https://mev-commit.xyz) preconfirmations. ERC-8004 registered (Agent #23175).
+- [Satoshi Facilitator](https://bitcoinsapi.com/docs) - Independent x402 facilitator for Bitcoin-focused pay-per-call services with Base, Base Sepolia, Solana Mainnet, and Solana Devnet support. [Supported networks](https://facilitator.bitcoinsapi.com/supported)
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
## Summary
- add `Satoshi Facilitator` to the `Facilitators` section

## Why
`Satoshi Facilitator` is the independent infrastructure layer behind Satoshi API and supports Base, Base Sepolia, Solana Mainnet, and Solana Devnet for Bitcoin-focused x402 payment flows.

## Validation
As of `2026-04-20`, the public facilitator surfaces resolve and return live support data:
- `https://facilitator.bitcoinsapi.com/supported`
- `https://facilitator.bitcoinsapi.com/discovery/resources?origin=https://bitcoinsapi.com`
- `https://bitcoinsapi.com/docs`

## Notes
- this PR adds a single resource at the bottom of the relevant category, following the repo contribution guide
