### PR TITLE
Add Boundary Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Enable AI agents to make autonomous payments.
 ### Agent Verification & Security
 
 - [Achilles EP AgentIAM](https://achillesalpha.onrender.com/quickstart) — 5 AI agent verification endpoints (NoLeak, MemGuard, RiskOracle, SecureExec, FlowCore) on Base Mainnet. $0.01-$0.02 USDC per call via x402.
+- [Boundary Guard](https://boundary-guard.vercel.app) - Pre-action checkpoint API for agents. Returns `allow`, `retry`, or `block` plus a deterministic receipt before downstream writes, sends, or other actions. Live docs and x402 inventory are published on the public host. ([GitHub](https://github.com/LarryLemonBot/boundary-guard))
 
 ### GPU Inference APIs
 


### PR DESCRIPTION
## Add Boundary Guard

**What:** Add Boundary Guard to the AI agent integration / agent verification area as an x402-native pre-action checkpoint API for agents.

**Why:** It gives x402 builders a narrow trust/control layer to run before downstream writes, sends, or other actions. Live public page, docs, and x402 inventory are already up.

**Quality Checklist:**
- [x] Resource is actively maintained
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** AI Agent Integration / Agent Verification and Security