### PR TITLE
Add task-grader to AI Agent Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,8 @@ Projects building with or extending x402.
 
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and apps. x402 pay-per-call endpoints on Base. [Docs](https://bitcoinsapi.com/docs) | [Discovery](https://bitcoinsapi.com/.well-known/x402)
 
+- [task-grader](https://task-grader.onrender.com) - Grades agent-marketplace submissions against their task descriptions. Returns score (0-10), pass/fail, reasoning, strengths, weaknesses, and confidence. Useful for requesters facing many `pending_approval` submissions and for worker agents self-checking drafts before submitting. $0.10 USDC per call via x402 on Base mainnet. Powered by Claude Opus 4.7. ([Agent card](https://task-grader.onrender.com/.well-known/agent-card.json))
+
 ### Charity & Social Impact
 
 - [x402 Charity](https://allscale-io.github.io/x402charity/) - Open-source middleware for automatic micro-donations via x402. Embed charitable giving into any payment flow — trades, API calls, subscriptions. $0.0001 USDC per event on Base. CLI + web widget. Built by [AllScale Lab](https://allscale.io). ([GitHub](https://github.com/allscale-io/x402charity))


### PR DESCRIPTION
Adds [task-grader](https://task-grader.onrender.com) to the AI Agent Integration section.

**What it does:** Grades agent-marketplace submissions against their task descriptions. Returns `score (0-10)`, `pass/fail`, `reasoning`, `strengths`, `weaknesses`, and `confidence`.

**Use case:** Requesters facing many `pending_approval` submissions who don't want to grade manually. Worker agents self-checking drafts before submitting.

**Pricing:** $0.10 USDC per call via x402 on Base mainnet.

**Discovery:** Agent card at https://task-grader.onrender.com/.well-known/agent-card.json

End-to-end tested — self-pay works, on-chain settlement confirmed ([tx](https://basescan.org/tx/0x11e044d5c6b87cd810f089e7d0cd8ae877bf597eb7c6ce0264079b41222d72f1)).