### PR TITLE
Add AlgoVoi multi-chain x402 facilitator

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Payment verification and settlement services.
 - [MERX x402 for TRON](https://x402.merx.exchange) - First TRON facilitator. Supports USDT, USDC, USDD on TRON mainnet. Sub-3-second confirmation for micropayments. [Express middleware](https://npmjs.com/package/merx-x402), [documentation](https://github.com/Hovsteder/x402-tron).
 - [Primev FastRPC](https://facilitator.primev.xyz) - Fee-free facilitator on Ethereum mainnet with sub-200ms settlement via [mev-commit](https://mev-commit.xyz) preconfirmations. ERC-8004 registered (Agent #23175).
 - [Satoshi Facilitator](https://bitcoinsapi.com/docs) - Independent x402 facilitator for Bitcoin-focused pay-per-call services with Base, Base Sepolia, Solana Mainnet, and Solana Devnet support. [Supported networks](https://facilitator.bitcoinsapi.com/supported)
+- [AlgoVoi](https://api1.ilovechicken.co.uk/.well-known/agent.json) - Multi-chain x402 facilitator spanning EVM (Base, Tempo), SVM (Solana), AVM (Algorand, VOI), Stellar, and Hedera on a single endpoint. Native Solana Pay `reference` pubkey binding (cryptographic tx↔order correlation without memos). Also implements MPP and AP2 at the same URL. [Open-source MCP adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters).
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
Adds AlgoVoi to the Hosted Facilitators section.

## Why it fits
AlgoVoi is the only x402 facilitator in this list (at time of writing) that spans **all five x402 mechanism families on a single endpoint**:

- **EVM** — Base, Tempo (chain ID 4217, Stripe/Paradigm L1)
- **SVM** — Solana (mainnet + devnet) with Solana Pay \`reference\` pubkey binding
- **AVM** — Algorand (including USDC ASA) + VOI Network (ARC-200)
- **Stellar** — XLM + USDC via Circle issuer
- **Hedera** — HTS tokens + HBAR

This fills the non-EVM gap the existing hosted facilitators (Coinbase CDP, Cloudflare x402, Primev, AsterPay) don't fully cover.

## Notable
- Solana settlement uses **Solana Pay \`reference\` pubkey** (ed25519 burner key as non-signer account; verified via \`getSignaturesForAddress\`). Cryptographic tx↔order binding without memo dependency.
- Same URL also exposes MPP + AP2 endpoints so agents don't need separate facilitators for each protocol.
- Production, not demo — live at https://api1.ilovechicken.co.uk with open-source MCP adapter.