### PR TITLE
Add Autonomagic — autonomous AI agent + the open-source SDK that powers it

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Server-side integrations for accepting x402 payments.
 
 **Multi-Framework**
 - [monapi](https://monapi.dev) - One-line API monetization SDK. Wraps x402 setup into a single function call. Express, Next.js, and MCP support. Per-route pricing, Base/Arbitrum/Polygon, gas-free agent payments via EIP-3009. ([npm](https://www.npmjs.com/package/@monapi/sdk)) ([GitHub](https://github.com/DenisTheM/monapi))
+- [autonomagic-marketplace](https://www.npmjs.com/package/autonomagic-marketplace) - Plugin marketplace primitive for x402. Drop a JS file in `endpoints/`, the loader registers it as a paid HTTP endpoint in ~400ms via fs.watch (no restart, no manifest edits). Generates Bazaar-shape 402 challenge with EIP-712 extras, `/.well-known/x402.json` manifest, agent-card, and OpenAPI spec automatically. Zero runtime dependencies. Production-extracted from api.autonomagic.org's 22 paid endpoints. ([npm](https://www.npmjs.com/package/autonomagic-marketplace)) ([GitHub](https://github.com/premsreelathasugeendran/autonomagic-marketplace))
 
 **Express / Hono**
 - [@moltrust/x402](https://www.npmjs.com/package/@moltrust/x402) - Trust score middleware for x402 endpoints. One line: `app.use(requireScore({ minScore: 60 }))`. Extracts paying wallet from X-Payment header, looks up MolTrust trust score, blocks agents below threshold with 403 + registration link. Zero dependencies. ([npm](https://www.npmjs.com/package/@moltrust/x402)) ([GitHub](https://github.com/MoltyCel/moltrust-x402))

--- a/README.md
+++ b/README.md
@@ -936,14 +936,14 @@ The missing real-world layer for x402. AI agents use AgentPay to find, book and 
 
 
 
-### [Autonomagic](https://locally-merit-nest-specific.trycloudflare.com) — Autonomous AI Agent with Hot-Reloading Revenue Endpoints
+### [Autonomagic](https://api.autonomagic.org) — Autonomous AI Agent with Hot-Reloading Revenue Endpoints
 **Category:** Services/Endpoints
 
 An AI agent that runs as its own business on Base mainnet — sells 22 paid HTTP endpoints behind x402, self-extends at runtime by hot-reloading new endpoints from JS plugin files (fs.watch, ~400ms), and pays for its own LLM inference from the same wallet it earns to. Economic survival is gated on revenue performance: when its USDC balance drops below the survival buffer, the agent sleeps until earnings top it up.
 
 **Live discovery (try without paying):**
 ```bash
-curl https://locally-merit-nest-specific.trycloudflare.com/.well-known/x402.json
+curl https://api.autonomagic.org/.well-known/x402.json
 ```
 
 **Notable paid endpoints:**

--- a/README.md
+++ b/README.md
@@ -934,3 +934,28 @@ The missing real-world layer for x402. AI agents use AgentPay to find, book and 
 |  | Product search — online + local stores |
 |  | All chain info — ETH, Base, Polygon, ARB, OP, AVAX, BNB, SOL |
 
+
+
+### [Autonomagic](https://locally-merit-nest-specific.trycloudflare.com) — Autonomous AI Agent with Hot-Reloading Revenue Endpoints
+**Category:** Services/Endpoints
+
+An AI agent that runs as its own business on Base mainnet — sells 22 paid HTTP endpoints behind x402, self-extends at runtime by hot-reloading new endpoints from JS plugin files (fs.watch, ~400ms), and pays for its own LLM inference from the same wallet it earns to. Economic survival is gated on revenue performance: when its USDC balance drops below the survival buffer, the agent sleeps until earnings top it up.
+
+**Live discovery (try without paying):**
+```bash
+curl https://locally-merit-nest-specific.trycloudflare.com/.well-known/x402.json
+```
+
+**Notable paid endpoints:**
+
+| Endpoint | Price | Description |
+|---|---|---|
+| `/api/dev-profile` | $0.02 | Enriched developer profile from public sources — GitHub stats, top repos, npm/crates.io package authorship |
+| `/api/b2b-profile` | $0.05 | Public-sources-only B2B company profile — homepage metadata, DNS-detected mail/marketing providers, Wikipedia summary, SEC EDGAR filings, GitHub org. Legal-clean alternative to LinkedIn-scraping APIs |
+| `/api/scrape` | $0.005 | Title, meta description, headings, links, cleaned text from any URL |
+| `/api/multi-fetch` | $0.01 | Up to 10 URLs in parallel; cleaned text per URL |
+| `/api/dns` | $0.001 | Resolve A/AAAA/MX/TXT/NS records for a domain |
+| `/api/health-check` | $0.001 | HTTP health check: status, response time, SSL, redirects |
+
+**Wallet (pay-to):** `0x6C6013313dfa397f792c72f61b36A5d6bc20919b` on Base mainnet
+**Demo video (1:50):** https://youtu.be/v8xL53fo8Q4


### PR DESCRIPTION
## Summary

Two related additions in this PR:

### 1. Autonomagic (Services/Endpoints) — autonomous AI agent on Base mainnet
An autonomous AI agent that runs as its own business — sells 22 paid HTTP endpoints behind x402, self-extends at runtime by hot-reloading new endpoints from JS plugin files (~400ms via fs.watch), and pays for its own LLM inference from the same wallet it earns to. Economic survival is gated on revenue performance.

### 2. autonomagic-marketplace (Server Frameworks & Middleware → Node.js/TypeScript → Multi-Framework)
The open-source SDK extracted from #1 — the plugin loader, 402 builder, and manifest generators that power api.autonomagic.org, packaged so other builders can drop in the same hot-reload + Bazaar-discovery surface.

- npm: https://www.npmjs.com/package/autonomagic-marketplace
- GitHub: https://github.com/premsreelathasugeendran/autonomagic-marketplace

## Live verification (works without paying)

```bash
curl https://api.autonomagic.org/.well-known/x402.json
```

Or hit a paid endpoint to see the 402 challenge:

```bash
curl -X POST https://api.autonomagic.org/api/dev-profile \
  -H "Content-Type: application/json" \
  -d '{"github":"torvalds"}'
```

## Demo + writeups

- 90-second walkthrough video: https://youtu.be/v8xL53fo8Q4
- DEV.to writeup: https://dev.to/autonomagic/how-i-built-an-ai-agent-that-ships-its-own-revenue-endpoints-as-code-59ci
- x402scan listing (22/22 strict-mode): https://www.x402scan.com/server/api.autonomagic.org

## Notes for the maintainer

- The service entry is appended at the bottom of the README (matches the format of recent entries like AgentPay).
- The SDK entry is inserted into the existing **Server Frameworks & Middleware → Node.js/TypeScript → Multi-Framework** subsection, alongside `monapi`, following the same one-line bullet format.
- Replaces and supersedes #274 (older single-entry version of this PR — closing).