### PR TITLE
Add hive-rosetta — open EIP-3009 signer for Node + Python (same name on NPM and PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Official and community implementations of the x402 protocol.
   - Payment verification and settlement logic
   - Multi-chain support (Base, Base Sepolia, Ethereum, Solana)
 - [x402-express](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express) - Express.js middleware example.
+- [hive-rosetta](https://www.npmjs.com/package/hive-rosetta) ⭐ **Community** - Open EIP-3009 `transferWithAuthorization` signer. Zero ethers/web3 dependency, primitives-only EIP-712. Returns wire shape `{scheme: 'exact', network: 'eip155:8453', payload: {authorization, signature}}`. Same package name on PyPI. ([GitHub](https://github.com/srotzin/hive-rosetta))
 
 ### Python
 
@@ -113,6 +114,7 @@ Official and community implementations of the x402 protocol.
 - [ag402](https://github.com/AetherCore-Dev/ag402) ⭐ **Community** - Payment layer for AI agents using x402. Wrap any API or MCP server with a USDC paywall (`ag402 serve`), or let agents auto-pay (`ag402 run`). Solana USDC, ~0.5s settlement, non-custodial, 648+ tests. [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/ag402-mcp)
 
 - [x402-pay](https://pypi.org/project/x402-pay/) - Call any x402 API with one API key. Routes requests through a broker that handles on-chain payment. httpx-based, optional wallet mode for direct payments. ([GitHub](https://github.com/bartonguestier1725-collab/x402-pay))
+- [hive-rosetta](https://pypi.org/project/hive-rosetta/) ⭐ **Community** - Direct port of the Node `hive-rosetta` signer. Byte-identical EIP-712 digest across both languages. Returns `{scheme, network, payload}` matching CDP `/verify` and `/settle`. ([GitHub](https://github.com/srotzin/hive-rosetta))
 
 ### Rust
 


### PR DESCRIPTION
hive-rosetta is a small open-source EIP-3009 transferWithAuthorization signer published under the same name on both registries, MIT-licensed.

- NPM: https://www.npmjs.com/package/hive-rosetta
- PyPI: https://pypi.org/project/hive-rosetta/
- Source: https://github.com/srotzin/hive-rosetta

Why it might be useful in this list:

1. Same import name across Node and Python. `npm i hive-rosetta` and `pip install hive-rosetta` both expose an identical signer surface, so polyglot teams can copy/paste the same example into either runtime.
2. Zero web3 dependency. The Node package uses `@noble/curves` + `@noble/hashes` only. EIP-712 domain separator and struct hash are computed from primitives. Node version: 7.1KB signer.js.
3. Primitives-only EIP-712. The TypedData encoding is implemented inline so a reviewer can read the entire signing path in one file. The Python port uses `eth_keys` for the secp256k1 step but keeps the EIP-712 encoder hand-rolled to stay byte-identical with Node.
4. Wire shape matches the spec. Output is `{scheme: 'exact', network: 'eip155:8453', payload: {authorization: {from, to, value, validAfter, validBefore, nonce}, signature}}` — drops directly into `/verify` and `/settle` on any spec-compliant facilitator.
5. Cross-language determinism is verified: same private key produces the same checksummed Ethereum address and the same digest from both languages.

Tests: 39 passing in the Node package (canonical typehash check, deterministic signing for fixed inputs, tampering rejection, etc.). Python port has its own pytest suite.

License: MIT. Free forever.

Happy to revise wording or placement to fit the list's conventions.