### PR TITLE
Add @larkinsh/x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Server-side integrations for accepting x402 payments.
 
 **Express / Hono**
 - [@moltrust/x402](https://www.npmjs.com/package/@moltrust/x402) - Trust score middleware for x402 endpoints. One line: `app.use(requireScore({ minScore: 60 }))`. Extracts paying wallet from X-Payment header, looks up MolTrust trust score, blocks agents below threshold with 403 + registration link. Zero dependencies. ([npm](https://www.npmjs.com/package/@moltrust/x402)) ([GitHub](https://github.com/MoltyCel/moltrust-x402))
+- [@larkinsh/x402](https://www.npmjs.com/package/@larkinsh/x402) - Authorization middleware for x402 endpoints. One line: `preflight(handler, { minScore: 40 })`. Gates by a 5-dimension trust score (wallet age, tx history, counterparties, funding source, ERC-8004), returns Ed25519-signed receipts verifiable with only the public key, supports block / warn / surcharge modes. Hono / Express / Next adapters. ([npm](https://www.npmjs.com/package/@larkinsh/x402)) ([GitHub](https://github.com/larkin-dev/larkin))
 
 **Next.js**
 - [x402-next](https://www.npmjs.com/package/x402-next) - App Router middleware.


### PR DESCRIPTION
Adds @larkinsh/x402 to Server Frameworks & Middleware → Express / Hono, alongside @moltrust/x402.

Authorization middleware for x402 endpoints. Wraps a paid handler with a one-line `preflight()` call, gates by a five-dimension wallet trust score, and returns Ed25519-signed receipts verifiable with only the published public key. Hono / Express / Next adapters; standalone verifier and MCP server published as separate packages.

Format mirrors @moltrust/x402's existing entry — package name as link text, hyphen separator, trailing parenthetical [npm] and [GitHub] links.