### PR TITLE
Add agenticpay — open-source TypeScript x402 facilitator for Solana

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Payment verification and settlement services.
   - REST API endpoints (/verify, /settle)
 - [Running Your Own Facilitator](https://github.com/x402-rs/x402-rs#facilitator) - Setup guide.
 - [@facilitator/eip7702](https://github.com/melonask/facilitator) - Support for all EVM blockchains (BNB, Polygon, etc.), all tokens (USDT, DAI, WBTC, etc.), and all native coins (POL, AVAX, etc.).
+- [agenticpay facilitator](https://github.com/krystiangw/agenticpay/tree/main/packages/facilitator) ([npm](https://www.npmjs.com/package/@agenticpay/facilitator)) - Open-source TypeScript facilitator for Solana (devnet + mainnet). Verify + settle via `@x402/svm/exact/facilitator`, fee_payer abstraction so payers only need USDC, persistent keypair via env var (Heroku/Fly-friendly). Hosted devnet endpoint: `https://agentpay-facilitator-e9b20a5fee6a.herokuapp.com`.
 
 ## 💡 Example Applications
 


### PR DESCRIPTION
Adds [agenticpay facilitator](https://github.com/krystiangw/agenticpay/tree/main/packages/facilitator) to the **🏗️ Facilitators / Self-Hosted Facilitators** section.

agenticpay is an open-source TypeScript implementation of the x402 facilitator spec for Solana. Built on `@x402/svm/exact/facilitator`, it ships with:

- Verify + settle endpoints (standard x402 spec, devnet + mainnet)
- Fee_payer abstraction — payers send only USDC; the facilitator covers SOL gas
- Persistent keypair via env var (Heroku/Fly slug-fs friendly)
- Rate limiting, min-amount floor, sanitized error responses (audit log in repo)
- npm package `@agenticpay/facilitator` for self-hosting in one command

Hosted free devnet endpoint anyone can point their `mcp-server` at:
`https://agentpay-facilitator-e9b20a5fee6a.herokuapp.com`

Repo (MIT): https://github.com/krystiangw/agenticpay
Landing: https://krystiangw.github.io/agenticpay/

Inserted at the end of the Self-Hosted Facilitators bullet list, after `@facilitator/eip7702`.