### PR TITLE
Add x402watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ Live metrics and on-chain analytics for the x402 ecosystem.
 - [Dune Analytics x402](https://dune.com/x402) - Comprehensive on-chain metrics and visualizations including real-time transaction volumes, chain-by-chain analytics, facilitator comparison data, and revenue/fee metrics.
 - [x402scan Explorer](https://x402scan.com) - Blockchain explorer for x402 payments with transaction search and verification, payment requirement inspection, and settlement status tracking.
 - [Valoria](https://x402.valoria.net) - x402 market intelligence with revenue rankings, service analysis, and pricing data across 90K+ indexed services and $148M+ in tracked on-chain volume.
+- [x402watch](https://x402.printmoneylab.com) - Wash-filtered intelligence layer for x402. 36k+ services indexed across Base, Solana, Polygon, and Arbitrum, AI-classified into 33 categories with 8-label buyer detection (organic_user, suspected_wash, self_test, developer, ai_agent, analytics_bot, exchange_user, verifier). 24h trends, anonymized case studies, daily CC0 datasets, x402-native paid API, and MCP server.
 - [CoinGecko x402 Category](https://coingecko.com/en/categories/x402) - Token tracking and market data featuring $180M+ tracked market cap, price charts, trading volumes, and ecosystem token listings.
 
 ### Growth Metrics


### PR DESCRIPTION
## Add x402watch — wash-filtered intelligence layer for x402

[x402watch](https://x402.printmoneylab.com) indexes 36k+ x402 services across Base, Solana, Polygon, and Arbitrum and classifies both services and buyer wallets, so the published metrics separate **real demand** from **wash / self-test / developer traffic**.

### What it adds to the list

- **Wash filter** — 8-label buyer classification (`organic_user`, `suspected_wash`, `self_test`, `developer`, `ai_agent`, `analytics_bot`, `exchange_user`, `verifier`) using cohort signals + vanity clustering. Real-volume reporting excludes the synthetic categories.
- **Free public data** — every label, every benchmark. Daily snapshots committed to a CC0 GitHub repo.
- **Time-series asset** — 30-day per-service / 365-day per-category windows.
- **AI-native** — public REST API, x402-native paid endpoints, llms.txt, OpenAPI, RSS, and an [MCP server](https://api.x402.printmoneylab.com/mcp) listed on the [official MCP Registry](https://registry.modelcontextprotocol.io) (`io.github.printmoneylab/x402watch`) and [Smithery](https://smithery.ai/servers/bakyang2/x402watch).

### Resources

- Live: <https://x402.printmoneylab.com>
- API: <https://api.x402.printmoneylab.com/api/v1> · [Swagger](https://api.x402.printmoneylab.com/docs)
- Methodology: <https://x402.printmoneylab.com/docs/methodology>
- Repo: <https://github.com/printmoneylab/x402watch> (Apache 2.0 code · CC0 data)

### Placement

Inserted into **Ecosystem Market Data → Analytics Dashboards**, after Valoria (closest scope: service-level intelligence). Single-line addition, no other changes.

Happy to adjust the entry wording or section if a different placement fits better.
