### PR TITLE
Add x402-saas to Hosted Facilitators

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Payment verification and settlement services.
 - [MERX x402 for TRON](https://x402.merx.exchange) - First TRON facilitator. Supports USDT, USDC, USDD on TRON mainnet. Sub-3-second confirmation for micropayments. [Express middleware](https://npmjs.com/package/merx-x402), [documentation](https://github.com/Hovsteder/x402-tron).
 - [Primev FastRPC](https://facilitator.primev.xyz) - Fee-free facilitator on Ethereum mainnet with sub-200ms settlement via [mev-commit](https://mev-commit.xyz) preconfirmations. ERC-8004 registered (Agent #23175).
 - [Satoshi Facilitator](https://bitcoinsapi.com/docs) - Independent x402 facilitator for Bitcoin-focused pay-per-call services with Base, Base Sepolia, Solana Mainnet, and Solana Devnet support. [Supported networks](https://facilitator.bitcoinsapi.com/supported)
+- [x402-saas](https://x402-saas.surge.sh) - Hosted facilitator + zero-SDK onboarding proxy on Base. SIWE auth, slug-routed multi-tenant data plane, 1% of routed USDC volume. MIT-licensed self-host alternative at [x402-kit](https://github.com/kite-builds-erik/x402-kit). Live demo at [`/__x402/health`](https://x402-saas.onrender.com/__x402/health).
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
Adds **x402-saas** to the Hosted Facilitators list — a hosted onboarding proxy for x402.

- Live: https://x402-saas.surge.sh
- Backend probe: https://x402-saas.onrender.com/__x402/health
- Source: https://github.com/kite-builds-erik/x402-saas (MIT, 38/38 tests)
- Self-host alternative: https://github.com/kite-builds-erik/x402-kit (also MIT)

The wedge over plain CDP/Coinbase facilitator is **zero-SDK integration**: developers point at any backend URL and get a paywalled proxy URL with a slug-routed multi-tenant data plane, SIWE auth, and a settled 99/1 split via the underlying facilitator.