### PR TITLE
Add MAKO — multi-route trust layer for agent commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,3 +934,5 @@ The missing real-world layer for x402. AI agents use AgentPay to find, book and 
 |  | Product search — online + local stores |
 |  | All chain info — ETH, Base, Polygon, ARB, OP, AVAX, BNB, SOL |
 
+
+- [MAKO](https://github.com/ChrisDover/mako-verifier) — x402 trust layer (Verifier $0.25 + Pulse $0.02 + Pricing Index $0.02 + Reputation Score $0.03) on Base. Live at mako.pollinateresearch.com.


### PR DESCRIPTION
Adding MAKO to the list under Agent Infrastructure (or Tools — let me know if a different section fits).

MAKO is an open, multi-route x402 service on Base that does pre-spend verification, per-endpoint reliability scoring (Pulse), market-rate pricing intelligence, and per-wallet operator reputation as four independently-callable paid endpoints. Live at `mako.pollinateresearch.com`, listed on agentic.market, currently scoring 142 services in its public Pulse scoreboard at `/pulse`.

Source: MIT-licensed TypeScript SDK + protocol spec at https://github.com/ChrisDover/mako-verifier.

Happy to adjust the entry length or section if needed.