### PR TITLE
Add mondello.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Written content about x402.
 - [Agentic Commerce](https://www.xpay.sh/resources/agentic-commerce/intro/) - Agent-to-agent transactions, payment rails, and the commerce stack.
 - [Agentic Economy Timeline](https://www.xpay.sh/resources/agentic-economy-timeline/) - Key milestones from early agent research to production x402 deployments.
 - AI Agents Need x402 - Future of autonomous payments.
+- [mondello.dev](https://mondello.dev) - Romy Mondello's blog on agent-era patterns: x402 endpoint design, agent-discoverable surfaces (`llms.txt`, OpenAPI 3.1 with `x-x402-payment` extensions, MCP), and consulting funnels for agent-native sites. Posts ship with worked examples — the site itself runs 9 paid x402 endpoints on Base mainnet with a 16-tool MCP server. ([llms.txt](https://mondello.dev/llms.txt) | [OpenAPI](https://mondello.dev/openapi.json) | [MCP](https://mondello.dev/api/mcp))
 
 ### News Coverage
 


### PR DESCRIPTION
## Add mondello.dev

**What:** A blog/consulting site by Romy Mondello focused on agent-era patterns. The entry is added to **Articles & Blog Posts → Use Case Articles**.

**Why:** Posts demonstrate concrete x402 patterns (endpoint design, payment-required flows, consulting funnels for agent-discoverable sites) with worked examples — the site itself eats its own dogfood, running 9 paid x402 endpoints on Base mainnet with full agent surfaces:

- [`/llms.txt`](https://mondello.dev/llms.txt) — surface atlas for agents
- [`/openapi.json`](https://mondello.dev/openapi.json) — OpenAPI 3.1 with `x-x402-payment` extensions on every paid path
- [`/api/mcp`](https://mondello.dev/api/mcp) — 16-tool MCP server (verified `initialize` + `tools/list`, JSON-RPC 2.0, protocol `2024-11-05`)
- [`/.well-known/agent-skills/index.json`](https://mondello.dev/.well-known/agent-skills/index.json) — 9 Claude Code skills, x402-paid

**Quality Checklist:**
- [x] Resource is actively maintained (last shipping log entry within the last week)
- [x] Well-documented — every agent surface is addressable + linked from `llms.txt`
- [x] Directly related to x402 protocol — 9 live x402 paid endpoints, OpenAPI extensions, posts on x402 patterns
- [x] All links working (verified)
- [x] Follows contribution format (`[Name](url) - Description.`)

**Category:** Articles & Blog Posts → Use Case Articles