### PR TITLE
Add @tensorfeed/x402-base-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 ### Model Context Protocol (MCP)
 
+- [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) - Read-only Base mainnet chain reader purpose-built for x402 payment verification. 11 tools: verify on-chain that a USDC settlement matches a claimed x402 receipt (recipient + amount), parse publisher `/.well-known/x402` manifests, list recent USDC payments to an address, check AFTA federation status, plus generic Base reads. No private keys, no signing, no broadcasts (verification only). Published with cryptographic provenance via GitHub Actions OIDC. `npx -y @tensorfeed/x402-base-mcp`. ([GitHub](https://github.com/RipperMercs/tensorfeed-x402-base-mcp)) ([MCP registry](https://registry.modelcontextprotocol.io/v0/servers/ai.tensorfeed/x402-base-mcp))
 - Anthropic MCP Integration - Official Claude integration.
 - x402 MCP Server - Claude Desktop ready server.
 - [MCP Server Setup Guide](https://docs.cdp.coinbase.com/x402/mcp-server) - Complete installation instructions.


### PR DESCRIPTION
Adds [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) to the Model Context Protocol (MCP) section.

**What it does:** Read-only Base mainnet chain reader purpose-built for x402 payment verification. 11 tools: verify on-chain that a USDC settlement matches a claimed x402 receipt, parse publisher `/.well-known/x402` manifests, list recent USDC payments, check AFTA federation status, plus generic Base reads (balance, usdc_balance, tx receipt, contract call, recent transfers).

**Differentiation:** Most existing MCP entries here facilitate making payments. This one is the verification side: any agent that receives an x402 receipt can independently confirm the on-chain USDC settlement matches the claim, without holding any private keys.

**Security profile:**
- Read-only (no private keys, no signing, no broadcasts)
- Published with cryptographic provenance attestations via GitHub Actions OIDC
- Socket.dev: Supply Chain 79, Quality 100, Vulnerability 100, License 100, Maintenance 86
- MIT

**Registry status:** Listed in the canonical MCP registry as `ai.tensorfeed/x402-base-mcp`.