### PR TITLE
Add switchboard to Python server frameworks & middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Server-side integrations for accepting x402 payments.
 **Client Libraries**
 - [x402 Payment Harness](https://github.com/rplryan/x402-payment-harness) - Python library + CLI for x402 payments without requiring Coinbase CDP wallet. Works with any Ethereum EOA. Full HTTP 402 -> EIP-712 sign -> X-PAYMENT header flow. `pip install x402-payment-harness`. ([PyPI](https://pypi.org/project/x402-payment-harness/))
 - [MoltsPay Python](https://github.com/Yaqing2023/moltspay-python) - Python SDK for x402 agent payments. LangChain compatible. Auto-creates wallets, discovers services, pays via x402. Multi-chain: Base, Polygon, Solana, BNB. ([PyPI](https://pypi.org/project/moltspay/))
+- [switchboard](https://github.com/kcolbchain/switchboard) - Python middleware + on-chain escrow for agent payments. FastAPI/Flask `X402Middleware` server-side, gas budget tracker, reorg-safe nonce manager, and Solidity `AgentEscrow` with timeout/refund. Protocol-agnostic substrate (x402 + escrow shipping; MPP/AP2 in flight).
 
 ### Rust
 


### PR DESCRIPTION
## What

Adds [switchboard](https://github.com/kcolbchain/switchboard) to **Server Frameworks & Middleware > Python > Client Libraries**.

## One-line addition

```markdown
- [switchboard](https://github.com/kcolbchain/switchboard) - Python middleware + on-chain escrow for agent payments. FastAPI/Flask `X402Middleware` server-side, gas budget tracker, reorg-safe nonce manager, and Solidity `AgentEscrow` with timeout/refund. Protocol-agnostic substrate (x402 + escrow shipping; MPP/AP2 in flight).
```

## Why it fits

- **x402-specific**: ships `switchboard/x402_middleware.py` — a server-side HTTP 402 middleware for FastAPI/Flask that verifies `X-PAYMENT` signatures and emits the standard `accepts[]` envelope.
- **Production-grade primitives few others have**: gas-budget tracker (per-hour/per-day caps), reorg-safe nonce manager, Solidity `AgentEscrow` with timeout + challenge period.
- **Actively maintained**: multiple shipped PRs from external contributors (#8 escrow, #11 nonce manager, #13/#14 gas budget). MIT license.
- **Open source, well-documented**: README walks through each module with diagrams; CONTRIBUTING.md present.

## Checklist

- [x] Search first — no existing switchboard entry
- [x] One change per PR — single line addition
- [x] Follows the format `[Resource Name](link) - Description.`
- [x] Link tested
- [x] Added at the bottom of the relevant category (Server Frameworks & Middleware > Python > Client Libraries)
- [x] Resource is x402-specific (ships `x402_middleware.py`)
- [x] Actively maintained, MIT licensed