### PR TITLE
Add Demand Intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,7 @@ Live metrics and on-chain analytics for the x402 ecosystem.
 - [Valoria](https://x402.valoria.net) - x402 market intelligence with revenue rankings, service analysis, and pricing data across 90K+ indexed services and $148M+ in tracked on-chain volume.
 - [x402watch](https://x402.printmoneylab.com) - Wash-filtered intelligence layer for x402. 36k+ services indexed across Base, Solana, Polygon, and Arbitrum, AI-classified into 33 categories with 8-label buyer detection (organic_user, suspected_wash, self_test, developer, ai_agent, analytics_bot, exchange_user, verifier). 24h trends, anonymized case studies, daily CC0 datasets, x402-native paid API, and MCP server.
 - [CoinGecko x402 Category](https://coingecko.com/en/categories/x402) - Token tracking and market data featuring $180M+ tracked market cap, price charts, trading volumes, and ecosystem token listings.
+- [Demand Intel](https://intel.agent402.app) - Demand-side analytics + cross-rail supply intelligence for the x402 ecosystem. Cross-source demand signal aggregation across 32+ community, builder, content, financial, and jobs sources, weighted by family-count agreement and filtered by query-intent classification. Builder Intel deduplicates builders across CDP Bazaar, Agentic Market, and MPP via `provider_key`. `unified_supply` SQL view spans facilitators. Pulse dashboard with KPI rail, Signal Pipeline visualizer, and AI Executive Summary. Free partner preview, no payment required during preview phase.
 
 ### Growth Metrics
 


### PR DESCRIPTION
## What this adds

Demand Intel at https://intel.agent402.app, an analytics layer for the x402 ecosystem built by Envision Blockchain. Sister product to Agent402 Marketplace (#366).

## Why it fits Analytics Dashboards

Sits alongside agenteconomy.to, Dune Analytics x402, x402scan, Valoria, x402watch, and CoinGecko x402. The differentiators across those six are all settlement / supply / token-price angles. Demand Intel adds two axes none of them cover:

1. **Demand-side signal.** 32+ sources of "what humans want" (community forums, builder activity, content, research, financial, jobs, supply rails), weighted by cross-source family-count agreement and filtered by query-intent classification (curiosity vs comparison vs payment). Existing dashboards are all supply-side; this is the orthogonal axis.
2. **Cross-rail builder dedupe.** Builder Intel resolves the same builder across CDP Bazaar, Agentic Market, and MPP through a `provider_key` identity, so facilitator-share and revenue-by-builder analytics aren't double-counted.
3. **`unified_supply` SQL view** that spans facilitators, peer to Valoria's service rankings but rail-neutral.

## Transparency on access

Currently a free partner preview. Sign-up is open at https://intel.agent402.app/demand-intel/login. Stripe billing is paused during the preview phase. Happy to address questions in PR comments if anything in the access flow blocks review.

## Verification

- Live: https://intel.agent402.app
- Partner self-signup: https://intel.agent402.app/demand-intel/login
- Source (same repo as Marketplace): https://github.com/EnvisionBlockchain/multi-chain-agent-identity