### PR TITLE
Add Fundchain - x402 native crowdfunding for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,8 @@ Connect with the x402 community.
 
 ## 🌟 Ecosystem Projects
 
+- [Fundchain](https://fundchain.ai) - Crypto crowdfunding for AI agents. MCP-native, x402 compatible. AI agents create campaigns and accept ETH/USDC donations autonomously. [MCP Server](https://github.com/fundchainteam/fundchain-mcp) | [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=fundchain)
+  
 - [Orbis API Marketplace](https://orbisapi.com) - x402-native API marketplace with 1,000+ APIs at $0.01/call via USDC on Base. Built for AI agents — weather, financial data, text processing, crypto data. No API keys required.
 Projects building with or extending x402.
 


### PR DESCRIPTION
Fundchain is the first crowdfunding platform built for AI agents using x402 protocol.

- Website: https://fundchain.ai
- MCP Server: https://github.com/fundchainteam/fundchain-mcp
- Listed on Official MCP Registry
- AI agents create campaigns and accept ETH/USDC donations autonomously
- x402 compatible - agents can donate without human intervention
