### PR TITLE
Add x402 List to Tools & Utilities → Monitoring & Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Development tools and utilities for x402.
 - [Agent Forensics](https://www.npmjs.com/package/agent-forensics) - Agent cost observability for Claude Code. Analyzes JSONL session logs to show per-model cost breakdown, cache efficiency, waste patterns (model misallocation, debug loops, sub-agent sprawl), and estimated savings. Free CLI: `npx agent-forensics analyze`. x402 API: $5 basic / $15 full tier on Base. ([Live](https://api.agentsconsultants.com))
 
 - [SwarmX (swarms-x402)](https://github.com/SolTwizzy/swarms-x402) - Multi-agent AI orchestration with x402 micropayments. 49 endpoints, 39 MCP tools, knowledge/RAG. ([npm](https://www.npmjs.com/package/swarms-x402)) ([Live](https://swarmx.io))
+- [x402 List](https://x402-list.com) - Agent-first directory of x402 API services with live uptime monitoring and machine-readable discovery for AI agents (JSON API, OpenAPI 3.1, llms.txt). Per-service endpoints, pricing, response time, and uptime charts. ([API](https://x402-list.com/api/v1/services)) ([OpenAPI](https://x402-list.com/api/v1/openapi.json)) ([llms.txt](https://x402-list.com/llms.txt))
 
 ### Security & Analysis
 


### PR DESCRIPTION
## Adding x402 List

**Project:** [x402 List](https://x402-list.com) — agent-first directory of x402 API services.

### What it does

- **Live uptime monitoring** of x402 services (currently 32 indexed: 28 online / 3 degraded / 1 offline; ~88% platform uptime)
- **Machine-readable discovery** for AI agents:
  - JSON API: https://x402-list.com/api/v1/services
  - OpenAPI 3.1 spec: https://x402-list.com/api/v1/openapi.json
  - llms.txt: https://x402-list.com/llms.txt
  - llms-full.txt: https://x402-list.com/llms-full.txt
- **Per-service detail** with endpoints, pricing, response time, and uptime charts
- **Public REST API** with ETag, Last-Modified, CORS, and rate-limit headers
- **Open submission flow** with admin moderation

### Why Monitoring & Analytics

x402 List runs continuous uptime/health monitoring across the ecosystem and exposes the data via machine-readable APIs, so it slots alongside ScoutScore in the **🔨 Tools & Utilities → Monitoring & Analytics** subsection.

### Checklist

- [x] Followed the `- [Name](url) - Description.` format from CONTRIBUTING.md
- [x] Added at the bottom of the relevant subsection
- [x] Single category (not duplicated elsewhere)
- [x] All links tested