### PR TITLE
Add x402trace to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Development tools and utilities for x402.
 
 - [Foundry](https://getfoundry.sh/) - Smart contract development toolkit.
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. `npx x402-proxy`. ([npm](https://www.npmjs.com/package/x402-proxy))
+- [x402trace](https://github.com/fardinvahdat/x402trace) - Local CLI debugger for x402 payment flows on Base. Catches the canonical reconciliation bug (wallet debited but server thinks payment failed, [coinbase/x402#1062](https://github.com/coinbase/x402/issues/1062)), pre-flights wallets, and explains failed 402s with actionable fixes. `npx x402trace`. ([npm](https://www.npmjs.com/package/x402trace))
 
 ### Monitoring & Analytics
 


### PR DESCRIPTION
Adds [x402trace](https://github.com/fardinvahdat/x402trace) under `🔨 Tools & Utilities → CLI Tools`, alongside the existing `x402-proxy` entry.

### What x402trace does

A local CLI debugger for x402 payment flows on Base. Catches the canonical reconciliation gap from [coinbase/x402#1062](https://github.com/coinbase/x402/issues/1062) — buyer's wallet is debited on-chain but the facilitator times out and the server thinks the payment failed. Plus pre-flight wallet checks (`validate`) and plain-English diagnosis of failed 402s (`explain`).

- npm: https://www.npmjs.com/package/x402trace
- Live tx from the demo: [`0x116ccf73…ba52` on basescan](https://sepolia.basescan.org/tx/0x116ccf73fa77eda19aea149606042f1e848e8afe2f719a0d2890dd2b2ff0ba52)

### Contribution checklist

- [x] One change per PR — single line added
- [x] Format matches the section's existing entries (specifically `x402-proxy` directly above)
- [x] Links resolve: [GitHub repo](https://github.com/fardinvahdat/x402trace), [npm](https://www.npmjs.com/package/x402trace), [coinbase/x402#1062](https://github.com/coinbase/x402/issues/1062)
- [x] Apache-2.0 licensed, open source
- [x] Published to npm (latest: `0.2.2`)