### PR TITLE
Add PQS Grade — pre-flight prompt quality scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Official and community implementations of the x402 protocol.
 
 - [ag402](https://github.com/AetherCore-Dev/ag402) ⭐ **Community** - Payment layer for AI agents using x402. Wrap any API or MCP server with a USDC paywall (`ag402 serve`), or let agents auto-pay (`ag402 run`). Solana USDC, ~0.5s settlement, non-custodial, 648+ tests. [Glama](https://glama.ai/mcp/servers/AetherCore-Dev/ag402-mcp)
 
-- [x402-pay](https://pypi.org/project/x402-pay/) - Call any x402 API with one API key. Routes requests through a broker that handles on-chain payment. httpx-based, optional wallet mode for direct payments. ([GitHub](https://github.com/bartonguestier1725-collab/x402-pay))
-
+- [x402-pay](https://pypi.org/project/x402-pay/) - Call any x402 API with one API key. Routes requests through a broker that handles on-chain payment. httpx-based, optional wallet mode for direct payments. ([GitHub](https://github.com/bartonguestier1725-collab/x402-pay)
+- [pqs-sdk](https://pypi.org/project/pqs-sdk/) - Python SDK for PQS (Prompt Quality Score). Score, optimize, and compare LLM prompts before inference. Works with LangChain, CrewAI, AutoGen. Free scoring, $0.025 USDC optimize, $1.25 USDC compare. ([GitHub](https://github.com/OnChainAIIntel/pqs-python-sdk))
 ### Rust
 
 - [x402-rs](https://github.com/x402-rs/x402-rs) ⭐ **Community** - Production-grade Rust implementation.

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Full working examples and templates.
 - [x402engine](https://x402engine.app) - Pay-per-call API gateway with 74 endpoints: 44 LLMs, image/video generation, crypto data, web search, code execution, TTS, travel, and IPFS. Multi-chain: USDC on Base, USDm on MegaETH, USDC on Solana. Discovery: [/.well-known/x402.json](https://x402engine.app/.well-known/x402.json) | [/.well-known/agent.json](https://x402engine.app/.well-known/agent.json). ([GitHub](https://github.com/agentc22/x402-engine)) | ([MCP](https://www.npmjs.com/package/x402engine-mcp))
 - [Trading Intelligence API](https://api.signalfuse.co) — Directional crypto trading signals fusing social sentiment, macro regime, and market structure. $0.001–$0.050 USDC per call on Base. 25 free credits per wallet. [Landing](https://signalfuse.co)
 
+- [PQS Grade](https://promptqualityscore.com/api/pqs-grade) - Pre-flight prompt quality scoring for LLMs. Returns composite score (0-100), letter grade (A-F), three framework sub-scores (PEEM, RAGAS, G-Eval), and verdict. Run upstream of any other paid endpoint to filter weak prompts before inference. $0.001 USDC per call on Base. ([MCP Server](https://www.npmjs.com/package/pqs-mcp-server)) | ([Methodology](https://promptqualityscore.com/blog/five-framework-synthesis))
+
 ### Client Examples
 
 - [Axios Client](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/axios) - Automatic payment handling.


### PR DESCRIPTION
Adds PQS Grade to the API Examples section. $0.001 USDC/call on Base via CDP facilitator. Returns composite score (0-100), letter grade, three framework sub-scores (PEEM, RAGAS, G-Eval), and verdict. Designed to run upstream of other paid endpoints to filter weak prompts before inference. Live and indexed in CDP Bazaar. Includes MCP server (`pqs-mcp-server@1.1.0` on npm) and methodology blog post.