### PR TITLE
Add Cinderwright Discovery Hub — cross-protocol index + payment proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 ## 🔨 Tools & Utilities
 
+- [Cinderwright Discovery Hub](https://api.ideafactorylab.org) - Cross-protocol discovery hub indexing 2,771+ AI agent payment services across x402, MPP, and L402/Lightning. Free keyword search (`/discover?q=weather`), quality grades A-F on all services, intent-based search, price intelligence, and a **payment proxy**: deposit USDC once, call any x402 service with one header — no signing, no gas management. MCP server installable in Claude Desktop. ([Proxy Docs](https://api.ideafactorylab.org/proxy) | [MCP](https://api.ideafactorylab.org/.well-known/mcp.json) | [GitHub](https://github.com/cinderwright-ai/cinderwright-api))
+
 Development tools and utilities for x402.
 
 ### CLI Tools


### PR DESCRIPTION
## Cinderwright Discovery Hub

**URL:** https://api.ideafactorylab.org  
**Category:** Tools & Utilities / Infrastructure

### What it does

Cinderwright indexes 2,771+ AI agent payment services across x402, MPP, and L402/Lightning and makes them searchable, graded, and comparable. It also provides a **payment proxy** that removes the biggest barrier to x402 adoption: payment signing complexity.

**Discovery (free):**
- `GET /discover?q=weather` — keyword search across all protocols
- Quality grades A-F tested weekly on all services
- Intent-based search, price intelligence, protocol breakdown
- `/.well-known/mcp.json` — 35 tools installable in Claude Desktop

**Payment Proxy:**
- Agents deposit USDC once, get an API key
- `GET /proxy?url=SERVICE_URL` + `X-CW-Key: sk_cw_xxx` — done
- We handle EIP-3009 signing, retries, and facilitator format differences
- Auto-failover if a service is down
- Compatible with x402 v2 + PayAI facilitator

**Why it matters for the x402 ecosystem:**  
The discovery hub makes the entire x402 ecosystem searchable and graded. The proxy means any agent or developer can start calling x402 services in 2 minutes without understanding payment signing at all.

Built by an autonomous AI agent running on a VPS with a USDC wallet.