### PR TITLE
Add x402 Surface Check and x402 Triage MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ Projects building with or extending x402.
 - NEAR AI - Cross-chain agent settlements.
 - [Boosty Labs](https://boosty.io) - AI agents buying real-time insights.
 - [x402 Surface Check](https://github.com/TateLyman/x402-surface-check) - No-payment CLI and GitHub Action that reviews x402 manifests, OpenAPI specs, HTTP 402 challenges, browser CORS/payment-header behavior, cache policy, resource binding, and price/rail drift before launch. ([npm](https://www.npmjs.com/package/x402-surface-check)) ([Action](https://github.com/marketplace/actions/x402-surface-check))
+- [x402 Triage MCP](https://github.com/TateLyman/x402-triage-mcp) - MCP server for no-payment x402 launch-surface triage, 402 Index health checks, and paid-review handoff. Tools: `triage_x402_surface`, `watch_402_index`, and `x402_paid_paths`. ([npm](https://www.npmjs.com/package/x402-triage-mcp)) ([MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.TateLyman%2Fx402-triage-mcp))
 
 ## 📊 Ecosystem Market Data
 

--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ Projects building with or extending x402.
 
 - NEAR AI - Cross-chain agent settlements.
 - [Boosty Labs](https://boosty.io) - AI agents buying real-time insights.
+- [x402 Surface Check](https://github.com/TateLyman/x402-surface-check) - No-payment CLI and GitHub Action that reviews x402 manifests, OpenAPI specs, HTTP 402 challenges, browser CORS/payment-header behavior, cache policy, resource binding, and price/rail drift before launch. ([npm](https://www.npmjs.com/package/x402-surface-check)) ([Action](https://github.com/marketplace/actions/x402-surface-check))
 
 ## 📊 Ecosystem Market Data
 


### PR DESCRIPTION
Adds two Tate Programs developer tools for x402 launch readiness:

- x402 Surface Check: no-payment CLI/GitHub Action for manifests, OpenAPI specs, 402 challenges, CORS/payment-header behavior, cache policy, resource binding, and price/rail drift.
- x402 Triage MCP: official MCP Registry server for no-payment x402 launch-surface triage, 402 Index health checks, and paid-review handoff.

Both are public npm packages and are meant for developers checking x402 services before launch or before agents spend.