### PR TITLE
Add x402-agent-monetizer: FastAPI @paywall decorator (Python, MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Server-side integrations for accepting x402 payments.
 
 **FastAPI**
 - [FastAPI example](https://github.com/coinbase/x402/tree/main/examples/python) - Complete implementation.
+- [x402-agent-monetizer](https://github.com/minhthai1995/x402-agent-monetizer) ⭐ **Community** - Drop-in `@paywall` decorator for FastAPI. One decorator gates any endpoint behind USDC on Base. Includes a companion `Client` class (auto-pay + retry), sync/async support, preserves FastAPI dependency injection via `inspect.signature.replace()`. MIT, Python 3.10+, 3 passing tests.
 
 **Client Libraries**
 - [x402 Payment Harness](https://github.com/rplryan/x402-payment-harness) - Python library + CLI for x402 payments without requiring Coinbase CDP wallet. Works with any Ethereum EOA. Full HTTP 402 -> EIP-712 sign -> X-PAYMENT header flow. `pip install x402-payment-harness`. ([PyPI](https://pypi.org/project/x402-payment-harness/))


### PR DESCRIPTION
Adds [x402-agent-monetizer](https://github.com/minhthai1995/x402-agent-monetizer) to the Python FastAPI section.

Drop-in `@paywall` decorator that gates any FastAPI endpoint behind USDC on Base. Uses `inspect.signature.replace()` to preserve dependency injection, supports sync + async handlers, includes companion `Client` class for auto-pay + retry. MIT, Python 3.10+, 3 tests passing.