### PR TITLE
Add x402trace under CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Development tools and utilities for x402.
 
 - [Foundry](https://getfoundry.sh/) - Smart contract development toolkit.
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. `npx x402-proxy`. ([npm](https://www.npmjs.com/package/x402-proxy))
+- [x402trace](https://github.com/fardinvahdat/x402trace) - Local CLI debugger for x402 on Base. Detects timeout-reconciliation gaps (the [#1062](https://github.com/coinbase/x402/issues/1062) settled-but-server-thinks-not pattern), validates `.well-known/x402` + Bazaar listings (the [#2207](https://github.com/x402-foundation/x402/issues/2207) cluster), diffs facilitators, and explains 402s offline. Read-only, no key handling. Sepolia + Base mainnet. `npx x402trace`. ([npm](https://www.npmjs.com/package/x402trace))
 
 ### Monitoring & Analytics
 


### PR DESCRIPTION
Adding [x402trace](https://github.com/fardinvahdat/x402trace) under `🔨 Tools & Utilities → CLI Tools` (next to `x402-proxy`, similar npm-installable CLI shape).

## What it is

A local CLI debugger for x402 on Base. Read-only, no key handling.

- **`x402trace proxy --reconcile`** — detects the [#1062](https://github.com/coinbase/x402/issues/1062) "settled-but-server-thinks-not" reconciliation gap by joining local proxy logs with Base USDC `Transfer` events.
- **`x402trace bazaar-check`** — validates `.well-known/x402` shape + `extensions.bazaar` + indexing query; emits a single verdict for the [#2207](https://github.com/x402-foundation/x402/issues/2207) cluster (is the bug yours, or upstream?).
- **`x402trace validate [--diff]`** — pre-flight wallet against a service's 402 challenge; with `--diff` runs the same payload through multiple facilitators (CDP, xpay, x402.org, PayAI) in parallel and surfaces drift.
- **`x402trace explain`** — plain-English diagnosis of a captured JSONL log, 15 diagnostic rules.

Verified against live Base Sepolia (three independent on-chain reconciliations).

## Links

- npm: https://www.npmjs.com/package/x402trace
- repo: https://github.com/fardinvahdat/x402trace
- v0.3.0 release: https://github.com/fardinvahdat/x402trace/releases/tag/v0.3.0

## Placement rationale

Best fit under `### CLI Tools` next to `x402-proxy` — both are npm-installable, both run locally, both target the operator-side debugging workflow. Not a SDK / facilitator / framework.