### PR TITLE
docs: fix 'Implementatdions' typo in TOC link label

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - [📖 Protocol Documentation](#-protocol-documentation)
 - [🚀 Quickstart Guides](#-quickstart-guides)
 - [⚙️ Protocol Implementations](#-protocol-implementations)
-- [🏭 Production Implementatdions](#-production-implementations)
+- [🏭 Production Implementations](#-production-implementations)
 - [🛠️ SDKs & Client Libraries](#-sdks--client-libraries)
 - [🔧 Server Frameworks & Middleware](#-server-frameworks--middleware)
 - [🏗️ Facilitators](#-facilitators)


### PR DESCRIPTION
Small docs fix — README.md line 14 had `Implementatdions` (extra `d`) in the table-of-contents link label for the Production Implementations section. The heading itself and the anchor are spelled correctly; just the label was off.

```diff
-- [🏭 Production Implementatdions](#-production-implementations)
+- [🏭 Production Implementations](#-production-implementations)
```

Caught while addressing review comments on #419.