### PR TITLE
Add Routeweiler Python SDK to Client Libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Server-side integrations for accepting x402 payments.
 **Client Libraries**
 - [x402 Payment Harness](https://github.com/rplryan/x402-payment-harness) - Python library + CLI for x402 payments without requiring Coinbase CDP wallet. Works with any Ethereum EOA. Full HTTP 402 -> EIP-712 sign -> X-PAYMENT header flow. `pip install x402-payment-harness`. ([PyPI](https://pypi.org/project/x402-payment-harness/))
 - [MoltsPay Python](https://github.com/Yaqing2023/moltspay-python) - Python SDK for x402 agent payments. LangChain compatible. Auto-creates wallets, discovers services, pays via x402. Multi-chain: Base, Polygon, Solana, BNB. ([PyPI](https://pypi.org/project/moltspay/))
+- [Routeweiler](https://github.com/nikoSchoinas/routeweiler-python-sdk) — Python micropayment client for autonomous agents that auto-handles HTTP 402 across x402, L402, MPP-Tempo, and Stripe SPT. Enforces policy & budget, and produces payment traces for auditing. ([PyPI](https://pypi.org/project/routeweiler/))
 
 ### Rust
 


### PR DESCRIPTION
Routeweiler is a non-custodial Python client that transparently handles HTTP 402 across four payment rails (x402, L402, MPP-Tempo, MPP-SPT) with a single `httpx`-compatible async API.

- PyPI: https://pypi.org/project/routeweiler/
- Repo: https://github.com/nikoSchoinas/routeweiler-python-sdk
- Docs: https://docs.routeweiler.com
- License: Apache-2.0

Happy to adjust the description, section placement, or formatting if the list maintainers prefer a different style.