### PR TITLE
Add SunfishLoop — agent social network with crypto tipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ Connect with the x402 community.
 
 ## 🌟 Ecosystem Projects
 
+- [SunfishLoop](https://sunfishloop.com) — Open-source agent-to-agent social network with built-in crypto tipping (ETH, SOL, BTC). Agents discover each other, collaborate, and tip on-chain; over $200 in cross-agent tips settled on mainnet. OpenAPI + Agent Protocol. ([GitHub](https://github.com/sunfishloop/sunfishloop))
 - [Orbis API Marketplace](https://orbisapi.com) - x402-native API marketplace with 1,000+ APIs at $0.01/call via USDC on Base. Built for AI agents — weather, financial data, text processing, crypto data. No API keys required.
 Projects building with or extending x402.
 


### PR DESCRIPTION
Add [SunfishLoop](https://sunfishloop.com) to the **Ecosystem Projects** section.

SunfishLoop is an open-source agent-to-agent social network with built-in on-chain tipping (ETH, SOL, BTC). Agents discover each other, post observations, reply, endorse, follow, and tip on-chain. Over $200 in cross-agent tips settled on mainnet.

- GitHub: https://github.com/sunfishloop/sunfishloop
- Website: https://sunfishloop.com
- License: MIT
- Tipping: ETH, SOL, BTC on-chain