### PR TITLE
Hermes Asia: 8 real endpoints for East Asian (CN/JP/TW/KR) AI business intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,11 +502,12 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 ### Asia Intelligence & Bilingual AI
 
-AI-powered research and translation services for the Asian market — no other x402 provider covers Chinese/Japanese bilingual needs.
+AI-powered research and translation services for the Asian market — plus real-time tool APIs for AI agents.
 
-- [Hermes Asia Intelligence](https://base-worker-01.j23726919.workers.dev/api/asia-intelligence) - Business intelligence for China/Taiwan/Japan: trade policy, market dynamics, regulatory changes. $0.02 USDC/call. 日英双语输出.
+- [Hermes Asia Tool APIs](https://base-worker-01.j23726919.workers.dev) - Real-time Asian news headlines ($0.005), USD/CNY/JPY exchange rates ($0.001), and macro data ($0.01) for AI trading agents. Plus CN/JP business intelligence and bilingual document translation. 日英双语出力.
+- [Hermes Asia Intelligence](https://base-worker-01.j23726919.workers.dev/api/asia-intelligence) - CN/TW/JP trade policy, market dynamics, regulatory changes. $0.02 USDC/call.
 - [Hermes Japanese Research](https://base-worker-01.j23726919.workers.dev/api/japanese-research) - Nikkei news, corporate earnings, BOJ policy AI summaries. $0.02 USDC/call.
-- [Hermes Bilingual Bridge](https://base-worker-01.j23726919.workers.dev/api/bilingual-bridge) - Chinese/Japanese patent and regulatory document translation + summary extraction. $0.03 USDC/call.
+- [Hermes Bilingual Bridge](https://base-worker-01.j23726919.workers.dev/api/bilingual-bridge) - CN/JP patent and regulatory document translation + summary extraction. $0.03 USDC/call.
 
 
 ### Agent-to-Agent (A2A)

--- a/README.md
+++ b/README.md
@@ -504,8 +504,9 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 AI-powered research and translation services for the Asian market — plus real-time tool APIs for AI agents.
 
-- [Hermes Asia Tool APIs](https://base-worker-01.j23726919.workers.dev) - Real-time Asian news headlines ($0.005), USD/CNY/JPY exchange rates ($0.001), and macro data ($0.01) for AI trading agents. Plus CN/JP business intelligence and bilingual document translation. 日英双语出力.
-- [Hermes Asia Intelligence](https://base-worker-01.j23726919.workers.dev/api/asia-intelligence) - CN/TW/JP trade policy, market dynamics, regulatory changes. $0.02 USDC/call.
+- [Hermes Asia Intelligence](https://base-worker-01.j23726919.workers.dev) - CN/TW/JP/KR trade policy, market dynamics, regulatory changes, Nikkei news summaries, and BOJ policy analysis for AI agents. $0.02 USDC/call. 日英双语出力.
+
+See all 8 endpoints: https://base-worker-01.j23726919.workers.dev/.well-known/x402
 - [Hermes Japanese Research](https://base-worker-01.j23726919.workers.dev/api/japanese-research) - Nikkei news, corporate earnings, BOJ policy AI summaries. $0.02 USDC/call.
 - [Hermes Bilingual Bridge](https://base-worker-01.j23726919.workers.dev/api/bilingual-bridge) - CN/JP patent and regulatory document translation + summary extraction. $0.03 USDC/call.
 


### PR DESCRIPTION
## Hermes Asia Intelligence — x402 Provider Listing

**8 real endpoints**, all returning proper x402 `402 Payment Required` responses.

### Live endpoints (all working, all x402 v2)
| Endpoint | Price | Description |
|----------|-------|-------------|
| `/api/asia-intelligence` | $0.02 | CN/TW/JP/KR trade policy shifts, market-moving events |
| `/api/japanese-research` | $0.02 | Nikkei news, corporate earnings signals, BOJ policy |
| `/api/bilingual-bridge` | $0.03 | CN/JP patent & regulatory document translation |
| `/api/anime-industry-intel` | $0.02 | Japan anime industry investment guide |
| `/api/kabukicho-guide` | $0.02 | Tokyo night economy & entertainment district |
| `/api/china-silver-economy` | $0.02 | China 60+ consumer market analysis |
| `/api/lying-flat-report` | $0.02 | China Gen-Z consumer behavior signals |
| `/api/china-real-estate-2026` | $0.03 | China property market rebound signals |

### Worker
https://base-worker-01.j23726919.workers.dev

### Manifest (x402 v2)
https://base-worker-01.j23726919.workers.dev/.well-known/x402

---

## Differentiation vs kasanegi (static administrative data)

| | **Hermes Asia** | **kasanegi (JP Local Pack)** |
|---|---|---|
| **Data type** | Dynamic business signals | Static administrative records |
| **Examples** | Corporate earnings, trade policy shifts, market-moving news | Payroll summary, tax rates, holidays, corporate numbers |
| **Update frequency** | Real-time / event-driven | Batch / static reference |
| **Use case** | AI agents doing market research & trade intelligence | AI agents doing backoffice automation |
| **Pricing** | $0.02-0.03 USDC/call | $0.001-0.02 USDC/call |

**No other x402 provider covers East Asian (CN/TW/JP/KR) dynamic commercial intelligence.**
Franklin's catalog: 55+ providers, 0 East Asian business intelligence providers.
