### PR TITLE
Add swerver x402 gateway proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Client libraries for making x402 payments.
 
 Server-side integrations for accepting x402 payments.
 
+### Gateway / Proxy
+- [swerver](https://x402.swerver.net) - High-performance x402 gateway proxy. Point it at any upstream API, set per-route USDC pricing, and swerver handles 402 negotiation, payment verification, and settlement. Built in Zig (3.4M rps on 64 cores). Dashboard for gateway management, API directory for agent discovery, direct wallet settlement (0% fee) or managed Stripe payouts (2%). Base network, USDC. ([Docs](https://x402.swerver.net/docs)) ([Directory](https://x402.swerver.net/directory))
+
 ### Node.js/TypeScript
 
 **Multi-Framework**


### PR DESCRIPTION
Adds [swerver](https://x402.swerver.net) to the Gateway / Proxy subsection under Server Frameworks & Middleware.

Swerver is a high-performance x402 gateway proxy built in Zig. It sits in front of any upstream API and handles 402 negotiation, payment verification, and USDC settlement on Base. Includes a management dashboard, public API directory for agent discovery, and supports both direct wallet settlement (0% fee) and managed Stripe payouts.

- Site: https://x402.swerver.net
- Docs: https://x402.swerver.net/docs
- Directory: https://x402.swerver.net/directory