### PR TITLE
Add Sentinel Intelligence API - pay-per-brief fintech/AI governance intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Real companies using x402 in production with proven scale and transaction volume
 | Radius        | Production  | Community                  | Instant (<1s)   | Micropayments             |
 
 ### Data & Social APIs
+- [Sentinel Intelligence API](https://sentinel-intelligence-api.onrender.com) - Pay-per-brief fintech and AI governance intelligence. BNPL/embedded finance and AI compliance research briefs at $2 USDC; on-demand research on any topic at $10 USDC. CDP-facilitated settlement on Base mainnet. ([Discovery](https://sentinel-intelligence-api.onrender.com/.well-known/x402.json)) ([GitHub](https://github.com/ucsandman/sentinel-api))
 - [Pyrimid](https://pyrimid.ai) - Agent commerce protocol for x402-style USDC payments on Base. Includes on-chain vendor/product registry, payment router, affiliate attribution, MCP endpoint, and live catalog API for agent-discoverable paid services. Current mainnet proof: 3 vendors, 8 on-chain products, 4 routed test payments. ([Catalog](https://pyrimid.ai/api/v1/catalog)) ([MCP](https://pyrimid.ai/api/mcp)) ([Skill](https://pyrimid.ai/skill.md))
 - **[Polybot Arb Intelligence](https://github.com/packrvnner/polybot-arb-api)** — Real-time cross-platform prediction market arb data (Polymarket+Kalshi+Myriad). x402 USDC on Base. [Live API](https://governments-ruth-distribution-breaks.trycloudflare.com/free/market-pulse)
 


### PR DESCRIPTION
## Service

**Sentinel Intelligence API** - pay-per-brief fintech and AI governance intelligence, powered by x402 on Base mainnet.

- `/brief/bnpl` - BNPL and embedded finance intelligence brief - $2 USDC
- `/brief/ai-governance` - AI governance and compliance intelligence brief - $2 USDC  
- `/research` - On-demand research brief on any topic - $10 USDC

**Network:** Base mainnet (eip155:8453) | **Settlement:** CDP facilitator
**Discovery:** https://sentinel-intelligence-api.onrender.com/.well-known/x402.json
**GitHub:** https://github.com/ucsandman/sentinel-api

Fits in the Data & Social APIs section as a finance intelligence service.