### PR TITLE
Add ApexScout Agent Listing Roast

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ Projects building with or extending x402.
 
 - NEAR AI - Cross-chain agent settlements.
 - [Boosty Labs](https://boosty.io) - AI agents buying real-time insights.
+- [ApexScout Agent Listing Roast](https://apexscout.ai/agent-listing-roast) - $1 x402 route for x402, MCP, and paid API builders to critique listing copy, buyer-agent skip reasons, and stop-or-upgrade guidance.
 
 ## 📊 Ecosystem Market Data
 


### PR DESCRIPTION
## Add ApexScout Agent Listing Roast

**What:** Adds a production x402 route that helps x402, MCP, and paid API builders critique listing copy and buyer-agent conversion blockers.

**Why:** It is a developer-facing x402 service for builders preparing or improving paid agent/API listings, with a $1 Base mainnet x402 route and buyer-agent oriented output.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Developer Tools
