### PR TITLE
Add x402-policy to API/agent projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,4 +1041,5 @@ curl https://api.autonomagic.org/.well-known/x402.json
 **Demo video (1:50):** https://youtu.be/v8xL53fo8Q4
 - [MAKO](https://github.com/ChrisDover/mako-verifier) — x402 trust layer (Verifier $0.25 + Pulse $0.02 + Pricing Index $0.02 + Reputation Score $0.03) on Base. Live at mako.pollinateresearch.com.
 - [NEXUS Agent Services](https://nexus-agent-xa12.onrender.com) - Real-time crypto prices, Reddit intelligence, DeFi data, stock prices, sentiment analysis. $0.001-0.05/call USDC on Base.
+- [- [x402-policy](https://x402-api-seven.vercel.app/docs) - Spending-policy enforcement for AI agents: pay-per-call policy checks, cross-chain trust scores, and EIP-4337 session keys, gated entirely by x402 micropayments ($0.001-0.002 USDC) on Base.
 * [AI Security API](http://203.194.112.129:3000) - Token risk analysis powered by MiniMax AI M2.7. Risk scoring 1-10 with detailed reasons. $0.02 USDC per call on Base mainnet. No signup required.


### PR DESCRIPTION
Adds x402-policy (https://x402-api-seven.vercel.app/docs) to the list of API/agent projects — a pay-per-call API that lets AI agents check spending policies, get cross-chain trust scores, and mint EIP-4337 session keys, gated entirely by x402 micropayments ($0.001-0.002 USDC) on Base.