### PR TITLE
Add gold-402 curated x402 directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,6 +970,7 @@ Contributions welcome! Please read the [contribution guidelines](CONTRIBUTING.md
 
 Looking for more awesome lists?
 - [awesome-molt-ecosystem](https://github.com/eltociear/awesome-molt-ecosystem) - Comprehensive guide to 200+ AI agent platforms with x402 economy analysis. Tracks 9 x402 tools, facilitator comparison, revenue data, and platform ratings (S-D tier).
+- [gold-402](https://github.com/Haustorium12/gold-402) - Curated x402 directory by 24K Labs. 300+ handpicked entries across facilitators, SDKs, MCP servers, APIs, and tools, with editorial writeups and verified badges for production-confirmed services.
 
 - [sindresorhus/awesome](https://github.com/sindresorhus/awesome) - The awesome list of awesome lists.
 - [Awesome Blockchain](https://github.com/yjjnls/awesome-blockchain) - Blockchain resources.


### PR DESCRIPTION
## Add gold-402

**What:** Curated x402 directory maintained by 24K Labs — 300+ handpicked entries with editorial context, verified badges, and a 29,000+ entry full catalog.

**Why:** The other awesome lists cover broad resources. gold-402 is x402-specific and editorially curated — every entry has to actually implement the protocol, not just use USDC. Fills the same slot awesome-molt-ecosystem fills but focused entirely on x402.

**Quality Checklist:**
- [x] Actively maintained (last push today)
- [x] Well-documented — CONTRIBUTING.md, badge system, articles
- [x] Directly related to x402 protocol
- [x] Link works
- [x] Follows contribution format

**Category:** Awesome Lists