### PR TITLE
Add Ontario Protocol (production x402 trust/verification API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Payment verification and settlement services.
 - [Running Your Own Facilitator](https://github.com/x402-rs/x402-rs#facilitator) - Setup guide.
 - [@facilitator/eip7702](https://github.com/melonask/facilitator) - Support for all EVM blockchains (BNB, Polygon, etc.), all tokens (USDT, DAI, WBTC, etc.), and all native coins (POL, AVAX, etc.).
 - [agenticpay facilitator](https://github.com/krystiangw/agenticpay/tree/main/packages/facilitator) ([npm](https://www.npmjs.com/package/@agenticpay/facilitator)) - Open-source TypeScript facilitator for Solana (devnet + mainnet). Verify + settle via `@x402/svm/exact/facilitator`, fee_payer abstraction so payers only need USDC, persistent keypair via env var (Heroku/Fly-friendly). Hosted devnet endpoint: `https://agentpay-facilitator-e9b20a5fee6a.herokuapp.com`.
+- [Ontario Protocol](https://ontarioprotocol.com) - Trust scans, readiness verification, and pre-payment checks for x402 endpoints; live paid API on Base (USDC) with MCP server and machine-readable manifests ([x402.json](https://ontarioprotocol.com/.well-known/x402.json)).
 
 ## 💡 Example Applications
 


### PR DESCRIPTION
Adds Ontario Protocol to Production Implementations.

Live surfaces:
- https://ontarioprotocol.com (production, Base mainnet, USDC)
- x402 manifest: https://ontarioprotocol.com/.well-known/x402.json
- MCP server: https://ontarioprotocol.com/mcp (listed in the official MCP registry as com.ontarioprotocol/ontario-protocol)
- Paid endpoints return spec-compliant 402 payment requirements via the Coinbase CDP facilitator

One resource, one line, per contribution guidelines. Happy to adjust placement or wording.