### PR TITLE
Add Forge Cascade

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Projects building with or extending x402.
 
 - [task-grader](https://task-grader.onrender.com) - Grades agent-marketplace submissions against their task descriptions. Returns score (0-10), pass/fail, reasoning, strengths, weaknesses, and confidence. Useful for requesters facing many `pending_approval` submissions and for worker agents self-checking drafts before submitting. $0.10 USDC per call via x402 on Base mainnet. Powered by Claude Opus 4.7. ([Agent card](https://task-grader.onrender.com/.well-known/agent-card.json))
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and apps. x402 pay-per-call endpoints on Base. [Docs](https://bitcoinsapi.com/docs) | [Discovery](https://bitcoinsapi.com/.well-known/x402)
+- [Forge Cascade](https://forgecascade.org/) - Experimental institutional memory and knowledge graph platform exposing x402 discovery metadata, payment OpenAPI docs, MCP, and A2A surfaces for Base USDC agent-commerce workflows. ([x402 discovery](https://forgecascade.org/.well-known/x402) | [Payment OpenAPI](https://forgecascade.org/openapi.payments.json) | [Agent card](https://forgecascade.org/.well-known/agent-card.json))
 
 ### Charity & Social Impact
 


### PR DESCRIPTION
﻿## What

Adds Forge Cascade to the Tools & Services section as an experimental x402-adjacent agent-commerce resource.

## Why

Forge exposes public x402 discovery metadata, payment OpenAPI docs, MCP, and A2A surfaces that are useful to developers exploring agent commerce and Base USDC payment workflows.

## Checks

- Verified the Forge homepage returns HTTP 200.
- Verified `/.well-known/x402` returns HTTP 200.
- Verified `/openapi.payments.json` returns HTTP 200.
- Verified `/.well-known/agent-card.json` returns HTTP 200.
- Ran `git diff --check`.
