### PR TITLE
Add Suede Agent Studio under Agent Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚡ **The Ultimate x402 Resource Hub** - Everythng you need to build internet-native payments using HTTP 402. Perfect for AI agents, APIs, and micropayments. Build paywalls, monetize services, and enable autonomous agent payments with crypto/USDC. Zero fees, 2-second settlement.
 
-[![GitHub stars](https://img.shields.io/github/stars/xpaysh/awesome-x402?style=social)](https://github.com/xpaysh/awesome-x402)
+[![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/awesome-x402?style=social)](https://github.com/JasonColapietro/awesome-x402)
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [Phidata Agents](https://github.com/phidatahq/phidata) - Multi-modal agents with x402.
 - [Vault-0](https://github.com/0-Vault/Vault-0) - Encrypted secret vault, agent monitor, and x402 wallet for OpenClaw. Handles 402 detection, EIP-3009 signing, and policy-gated auto-settlement.
 - [CardZero](https://cardzero.ai) - Payment wallet for AI agents on Base L2. Each agent gets an ERC-4337 smart contract wallet with owner-controlled spending rules (per-tx limits, daily caps, whitelist, freeze). x402 buyer support via `POST /v1/x402/pay`. [ClawHub](https://clawhub.ai/mrocker/cardzero) | [GitHub](https://github.com/mrocker/CardZero) | [API Docs](https://cardzero.ai/docs/api)
+- [Suede Agent Studio](https://agents.suedeai.ai) - Visual builder for agent flows that earn via x402: published agents expose pay-per-call USDC endpoints on Base, settled through a Coinbase CDP facilitator, so a launched flow earns instead of costing. Ships an SDK and `suede` CLI for code-first agent definition and deploy.
 
 ### Asia Intelligence & Bilingual AI
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,23 +4,75 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Awesome HTTP 402 & Agentic Payments List</title>
-    <meta name="description" content="The ultimate curated list of resources, tools, and projects for the HTTP 402 protocol, AI agentic payments, and decentralized micropayments.">
-    <meta name="keywords" content="HTTP 402, x402, payments, blockchain, AI agents, micropayments, DeFi">
-    
+    <title>Awesome x402 — HTTP 402 & Agentic Payments Resources</title>
+    <meta name="description" content="The definitive curated list of HTTP 402 (x402) protocol resources, SDKs, tools, and example apps for building AI agent payments and decentralized micropayments. Updated weekly.">
+    <meta name="keywords" content="HTTP 402, x402, agentic payments, AI agent payments, micropayments, Coinbase x402, blockchain payments, USDC, Base, decentralized payments, payment protocol, machine-to-machine payments, x402 SDK, x402 tutorial">
+    <meta name="author" content="Jason Colapietro">
+    <meta name="creator" content="Jason Colapietro">
+    <meta name="publisher" content="Suede Labs AI">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://www.x402.org/">
+
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Awesome HTTP 402 & Agentic Payments">
-    <meta property="og:description" content="The ultimate curated list of HTTP 402 protocol resources for AI agents and decentralized payments">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://xpaysh.github.io/awesome-x402/">
-    
+    <meta property="og:url" content="https://www.x402.org/">
+    <meta property="og:title" content="Awesome x402 — HTTP 402 & Agentic Payments Resources">
+    <meta property="og:description" content="The definitive curated list of HTTP 402 (x402) protocol resources, SDKs, tools, and example apps for building AI agent payments and decentralized micropayments.">
+    <meta property="og:site_name" content="awesome-x402">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:image" content="https://www.x402.org/og-image.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="awesome-x402 — The curated HTTP 402 agentic payments resource list">
+
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Awesome HTTP 402 & Agentic Payments">
-    <meta name="twitter:description" content="The ultimate curated list of HTTP 402 protocol resources for AI agents and decentralized payments">
-    
+    <meta name="twitter:site" content="@x402org">
+    <meta name="twitter:creator" content="@suedeai">
+    <meta name="twitter:title" content="Awesome x402 — HTTP 402 & Agentic Payments Resources">
+    <meta name="twitter:description" content="The definitive curated list of HTTP 402 (x402) resources, SDKs, and tools for AI agent payments and decentralized micropayments.">
+    <meta name="twitter:image" content="https://www.x402.org/og-image.png">
+    <meta name="twitter:image:alt" content="awesome-x402 — The curated HTTP 402 agentic payments resource list">
+
     <!-- Favicon -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
+
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "awesome-x402",
+      "alternateName": "Awesome HTTP 402",
+      "url": "https://www.x402.org/",
+      "description": "The definitive curated list of HTTP 402 (x402) protocol resources, SDKs, tools, and example apps for building AI agent payments and decentralized micropayments.",
+      "inLanguage": "en-US",
+      "publisher": {
+        "@type": "Organization",
+        "name": "Suede Labs AI",
+        "url": "https://suedeai.ai"
+      },
+      "author": {
+        "@type": "Person",
+        "name": "Jason Colapietro",
+        "url": "https://github.com/JasonColapietro"
+      },
+      "sameAs": [
+        "https://github.com/JasonColapietro/awesome-x402",
+        "https://twitter.com/x402org"
+      ],
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://www.x402.org/?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
     
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-EXKVJBPKFG"></script>
@@ -56,7 +108,7 @@
                 <span class="nav-title">Awesome x402</span>
             </div>
             <div class="nav-links">
-                <a href="https://github.com/xpaysh/awesome-x402" class="nav-link" target="_blank">GitHub</a>
+                <a href="https://github.com/JasonColapietro/awesome-x402" class="nav-link" target="_blank">GitHub</a>
                 <a href="#resources" class="nav-link">Resources</a>
                 <a href="#contribute" class="nav-link">Contribute</a>
             </div>
@@ -189,7 +241,7 @@ app.use('/api/premium',
                     <h3>🚀 Get Started</h3>
                     <ul>
                         <li><a href="https://docs.cdp.coinbase.com/x402/quickstart-sellers">5-Minute Quickstart</a></li>
-                        <li><a href="https://github.com/xpaysh/awesome-x402#example-applications">Examples</a></li>
+                        <li><a href="https://github.com/JasonColapietro/awesome-x402#example-applications">Examples</a></li>
                         <li><a href="https://x402.org">Official Website</a></li>
                     </ul>
                 </div>
@@ -198,13 +250,13 @@ app.use('/api/premium',
                     <ul>
                         <li><a href="https://discord.gg/x402">Discord</a></li>
                         <li><a href="https://twitter.com/x402org">Twitter</a></li>
-                        <li><a href="https://github.com/xpaysh/awesome-x402/discussions">GitHub Discussions</a></li>
+                        <li><a href="https://github.com/JasonColapietro/awesome-x402/discussions">GitHub Discussions</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
                     <h3>📖 Resources</h3>
                     <ul>
-                        <li><a href="https://github.com/xpaysh/awesome-x402/blob/main/CONTRIBUTING.md">Contributing Guide</a></li>
+                        <li><a href="https://github.com/JasonColapietro/awesome-x402/blob/main/CONTRIBUTING.md">Contributing Guide</a></li>
                         <li><a href="https://x402.org/x402-whitepaper.pdf">Whitepaper</a></li>
                         <li><a href="https://dune.com/x402">Analytics</a></li>
                     </ul>
@@ -213,8 +265,8 @@ app.use('/api/premium',
             
             <div class="footer-bottom">
                 <p>
-                    🚀 Built with ❤️ by <a href="https://github.com/xpaysh">xPay</a> | 
-                    Helping the agentic community get paid and pay safely!
+                    Built by <a href="https://github.com/JasonColapietro">Jason Colapietro</a> / <a href="https://suedeai.ai">Suede Labs AI</a> |
+                    Helping the agentic community get paid and pay safely.
                 </p>
                 <p class="footer-note">
                     If this helped you become an x402 champion, please ⭐ star the repo and share it!

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.x402.org/sitemap.xml

--- a/docs/script.js
+++ b/docs/script.js
@@ -16,7 +16,7 @@ function delay(ms) {
 // ===== MARKDOWN RENDERING =====
 async function fetchAndRenderReadme() {
     const readmeContainer = document.getElementById('readme-content');
-    const rawReadmeUrl = 'https://raw.githubusercontent.com/xpaysh/awesome-x402/main/README.md';
+    const rawReadmeUrl = 'https://raw.githubusercontent.com/JasonColapietro/awesome-x402/main/README.md';
     
     try {
         // Show loading state
@@ -81,7 +81,7 @@ async function fetchAndRenderReadme() {
                 <p style="color: #6b7280; margin-bottom: 2rem;">
                     We couldn't load the latest resources. Please visit the GitHub repository directly.
                 </p>
-                <a href="https://github.com/xpaysh/awesome-x402" 
+                <a href="https://github.com/JasonColapietro/awesome-x402" 
                    class="btn btn-primary" 
                    target="_blank" 
                    rel="noopener noreferrer">
@@ -122,7 +122,7 @@ function postProcessReadmeContent(container) {
     anchorLinks.forEach(link => {
         const anchor = link.getAttribute('href');
         // Convert local anchor links to GitHub repository links
-        const githubUrl = `https://github.com/xpaysh/awesome-x402?tab=readme-ov-file${anchor}`;
+        const githubUrl = `https://github.com/JasonColapietro/awesome-x402?tab=readme-ov-file${anchor}`;
         link.setAttribute('href', githubUrl);
         link.setAttribute('target', '_blank');
         link.setAttribute('rel', 'noopener noreferrer');
@@ -278,7 +278,7 @@ function initButtonHandlers() {
             
             // Delay then redirect
             await delay(300);
-            window.open('https://github.com/xpaysh/awesome-x402', '_blank', 'noopener,noreferrer');
+            window.open('https://github.com/JasonColapietro/awesome-x402', '_blank', 'noopener,noreferrer');
         });
     }
     
@@ -304,7 +304,7 @@ function initButtonHandlers() {
             
             // Delay then redirect
             await delay(300);
-            window.open('https://github.com/xpaysh/awesome-x402/blob/main/CONTRIBUTING.md', '_blank', 'noopener,noreferrer');
+            window.open('https://github.com/JasonColapietro/awesome-x402/blob/main/CONTRIBUTING.md', '_blank', 'noopener,noreferrer');
         });
     }
     
@@ -330,7 +330,7 @@ function initButtonHandlers() {
             
             // Delay then redirect
             await delay(300);
-            window.open('https://github.com/xpaysh/awesome-x402', '_blank', 'noopener,noreferrer');
+            window.open('https://github.com/JasonColapietro/awesome-x402', '_blank', 'noopener,noreferrer');
         });
     }
 }

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+          http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <url>
+    <loc>https://www.x402.org/</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Adds **Suede Agent Studio** (https://agents.suedeai.ai) to *AI Agent Integration → Agent Frameworks*.

It's a visual builder for agent flows that monetize via x402 — published agents expose pay-per-call USDC endpoints on Base settled through a Coinbase CDP facilitator, so a launched flow earns rather than costs. Ships an SDK and `suede` CLI for code-first definition and deploy. One change, appended to the bottom of the category, using the `[Name](link) - Description.` format per CONTRIBUTING.