### PR TITLE
Add GEDX402 — Workers AI x402 inference hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 - [GPU-Bridge](https://gpubridge.xyz) - 30-service GPU inference API with native x402 payments (USDC on Base L2). LLM, image generation, embeddings, STT, TTS, PDF processing — all in one API. Agents pay per call with no human intervention. /usr/bin/bash.00002/embedding, /usr/bin/bash.001/LLM call. ([Docs](https://docs.gpubridge.xyz)) ([GitHub](https://github.com/fjnunezp75/gpu-bridge))
 
+- [GEDX402](https://ged-x402.jvalamis.workers.dev) — Cloudflare Workers AI hub with x402 v2 USDC (Base, Polygon, Arbitrum, World, Solana). Eight modality shards. [Hub](https://ged-x402.jvalamis.workers.dev) | [agents.json](https://ged-x402.jvalamis.workers.dev/.well-known/agents.json) | [OpenAPI](https://ged-x402.jvalamis.workers.dev/openapi.json) | [x402](https://ged-x402.jvalamis.workers.dev/.well-known/x402) | [MCP](https://github.com/scrolls-cf/ged-x402)
+
 ### Model Context Protocol (MCP)
 
 - Anthropic MCP Integration - Official Claude integration.

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 - [GPU-Bridge](https://gpubridge.xyz) - 30-service GPU inference API with native x402 payments (USDC on Base L2). LLM, image generation, embeddings, STT, TTS, PDF processing — all in one API. Agents pay per call with no human intervention. /usr/bin/bash.00002/embedding, /usr/bin/bash.001/LLM call. ([Docs](https://docs.gpubridge.xyz)) ([GitHub](https://github.com/fjnunezp75/gpu-bridge))
 
-- [GEDX402](https://ged-x402.jvalamis.workers.dev) — Cloudflare Workers AI hub with x402 v2 USDC (Base, Polygon, Arbitrum, World, Solana). Eight modality shards. [Hub](https://ged-x402.jvalamis.workers.dev) | [agents.json](https://ged-x402.jvalamis.workers.dev/.well-known/agents.json) | [OpenAPI](https://ged-x402.jvalamis.workers.dev/openapi.json) | [x402](https://ged-x402.jvalamis.workers.dev/.well-known/x402) | [MCP](https://github.com/scrolls-cf/ged-x402)
+- [GEDX402](https://gedx402.com) — Cloudflare Workers AI hub with x402 v2 USDC (Base, Polygon, Arbitrum, World, Solana). Eight modality shards. [Hub](https://gedx402.com) | [agents.json](https://gedx402.com/.well-known/agents.json) | [OpenAPI](https://gedx402.com/openapi.json) | [x402](https://gedx402.com/.well-known/x402) | [MCP](https://github.com/scrolls-cf/ged-x402)
 
 ### Model Context Protocol (MCP)
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 - [GPU-Bridge](https://gpubridge.xyz) - 30-service GPU inference API with native x402 payments (USDC on Base L2). LLM, image generation, embeddings, STT, TTS, PDF processing — all in one API. Agents pay per call with no human intervention. /usr/bin/bash.00002/embedding, /usr/bin/bash.001/LLM call. ([Docs](https://docs.gpubridge.xyz)) ([GitHub](https://github.com/fjnunezp75/gpu-bridge))
 
-- [GEDX402](https://gedx402.com) — Cloudflare Workers AI hub with x402 v2 USDC (Base, Polygon, Arbitrum, World, Solana). Eight modality shards. [Hub](https://gedx402.com) | [agents.json](https://gedx402.com/.well-known/agents.json) | [OpenAPI](https://gedx402.com/openapi.json) | [x402](https://gedx402.com/.well-known/x402) | [MCP](https://github.com/scrolls-cf/ged-x402)
+- [GEDX402](https://gedx402.com) - Cloudflare Workers AI hub with x402 v2 USDC (Base, Polygon, Arbitrum, World, Solana). Eight modality shards. [Hub](https://gedx402.com) | [agents.json](https://gedx402.com/.well-known/agents.json) | [OpenAPI](https://gedx402.com/openapi.json) | [x402](https://gedx402.com/.well-known/x402) | [MCP](https://github.com/scrolls-cf/ged-x402)
 
 ### Model Context Protocol (MCP)
 


### PR DESCRIPTION
## Summary

Adds **GEDX402** to the GPU Inference APIs section — a Cloudflare Workers AI hub with native x402 v2 USDC micropayments across eight modality shards (chat, LLM, embed, image, media, browser, search, jobs).

## What is GEDX402?

- **Hub** at https://gedx402.com — catalog (`GET /v1/models`), OpenAPI 3.1, agents.json manifest, x402 discovery
- **Eight modality shards** — each shard origin exposes paid POST routes with HTTP 402 USDC quotes; multi-chain (Base, Polygon, Arbitrum, World, Solana)
- **Agent-ready** — `/.well-known/agents.json`, `/.well-known/x402`, OpenAPI per shard; MCP server in [scrolls-cf/ged-x402](https://github.com/scrolls-cf/ged-x402)
- **Dynamic pricing** — per-route x402 quotes tied to Workers AI compute

## Discovery links

| Resource | URL |
| --- | --- |
| Hub | https://gedx402.com |
| Catalog | https://gedx402.com/v1/models |
| agents.json | https://gedx402.com/.well-known/agents.json |
| OpenAPI | https://gedx402.com/openapi.json |
| x402 | https://gedx402.com/.well-known/x402 |
| x402 (extended) | https://gedx402.com/.well-known/x402.json |
| MCP repo | https://github.com/scrolls-cf/ged-x402 |

### Shard origins

| Shard | Origin |
| --- | --- |
| Chat | https://chat.gedx402.com |
| LLM | https://llm.gedx402.com |
| Knowledge (embed) | https://embed.gedx402.com |
| Image | https://image.gedx402.com |
| Media | https://media.gedx402.com |
| Browser | https://browser.gedx402.com |
| Search | https://search.gedx402.com |
| Jobs | https://jobs.gedx402.com |

Regenerate locally: `npm run discovery:links` in [ged-x402](https://github.com/scrolls-cf/ged-x402).

## Checklist

- [x] Link points to a live x402-enabled service
- [x] Entry placed in the correct section (GPU Inference APIs)
- [x] Description is concise and follows existing list style
- [x] agents.json validates at https://agent-ready.dev/agents-json-validator?url=https://gedx402.com/.well-known/agents.json