### PR TITLE
Add Listing Roast x402

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ Projects building with or extending x402.
 
 - [task-grader](https://task-grader.onrender.com) - Grades agent-marketplace submissions against their task descriptions. Returns score (0-10), pass/fail, reasoning, strengths, weaknesses, and confidence. Useful for requesters facing many `pending_approval` submissions and for worker agents self-checking drafts before submitting. $0.10 USDC per call via x402 on Base mainnet. Powered by Claude Opus 4.7. ([Agent card](https://task-grader.onrender.com/.well-known/agent-card.json))
 - [Satoshi API](https://bitcoinsapi.com) - Bitcoin fee market, next-block mining, and transaction intelligence API for agents and apps. x402 pay-per-call endpoints on Base. [Docs](https://bitcoinsapi.com/docs) | [Discovery](https://bitcoinsapi.com/.well-known/x402)
+- [Listing Roast x402](https://listing-roast-x402-service-production.up.railway.app) - Paid x402 API for builders launching agent-facing services: $0.001 listing scores, $0.01 full roasts, and a $0.01 Bazaar discovery audit for stale pricing, direct 402 metadata, and search visibility on Base USDC.
 
 ### Charity & Social Impact
 


### PR DESCRIPTION
## Add Listing Roast x402

**What:** Adds Listing Roast x402, a paid x402 API for listing scores, full roasts, and Bazaar discovery audits.

**Why:** It helps x402 builders check paid service listing clarity and diagnose stale Bazaar pricing/search visibility.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Ecosystem Projects / Tools & Services