### PR TITLE
Add Crest x402 Data (agent profiling + crypto market data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ Comprehensive guides for migrating from traditional payment systems to x402.
 *[KaelAi] (https://kaelai.io) - Wallet trust scoring API for the agentic economy. Scores wallets 0-100 across 10 chains with behavioural analysis. Built for x402 servers to vet incoming and outgoing payment wallets before serving or initiating requests. 
 
 - [stripe-mcps](https://www.npmjs.com/package/stripe-mcps) - Trust verification + AML sanctions screening before Stripe/x402 payments. Agent identity (ECDSA), 75K+ sanctions entries (UK HMT + OFAC SDN), behavioural spend limits. OWASP MCP Security Cheat Sheet aligned. ([GitHub](https://github.com/razashariff/stripe-mcps))
+- [Crest Verify](https://verify.crestsystems.ai) - Verification tools for x402 endpoints, including conformance checks, service indexing, and signed trust receipts. ([npm](https://npmjs.com/package/@crestdeploymentsystems/verify) | [GitHub](https://github.com/andysalvo/crest))
 Security resources and best practices for x402 implementations.
 
 ### Smart Contract Audits

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Real companies using x402 in production with proven scale and transaction volume
 | Radius        | Production  | Community                  | Instant (<1s)   | Micropayments             |
 
 ### Data & Social APIs
+- [Crest x402 Data](https://data.crestsystems.ai) - x402 agent profiling plus crypto market data. Profile any x402 buyer or EVM wallet (whale score, behavior cluster, x402 spend graph, risk), plus prices, gas, DeFi, derivatives, NFTs, and DEX pairs. $0.002-$0.90 USDC on Base via Coinbase CDP facilitator, no API keys. ([Agent Card](https://data.crestsystems.ai/.well-known/agent.json) | [llms.txt](https://data.crestsystems.ai/llms.txt) | [l402-services](https://data.crestsystems.ai/.well-known/l402-services))
 - [Pyrimid](https://pyrimid.ai) - Agent commerce protocol for x402-style USDC payments on Base. Includes on-chain vendor/product registry, payment router, affiliate attribution, MCP endpoint, and live catalog API for agent-discoverable paid services. Current mainnet proof: 3 vendors, 8 on-chain products, 4 routed test payments. ([Catalog](https://pyrimid.ai/api/v1/catalog)) ([MCP](https://pyrimid.ai/api/mcp)) ([Skill](https://pyrimid.ai/skill.md))
 - **[Polybot Arb Intelligence](https://github.com/packrvnner/polybot-arb-api)** — Real-time cross-platform prediction market arb data (Polymarket+Kalshi+Myriad). x402 USDC on Base. [Live API](https://governments-ruth-distribution-breaks.trycloudflare.com/free/market-pulse)
 


### PR DESCRIPTION
Adds **Crest x402 Data** to the Data & Social APIs section.

Live x402 service on Base, settled via the Coinbase CDP facilitator (indexed in the CDP Bazaar). Distinct angle: **x402 agent profiling** — a wallet-intelligence endpoint that profiles x402 buyers (whale score, behavior cluster, spend graph, risk) on top of a standard crypto market-data suite (prices, gas, DeFi, derivatives, NFTs, DEX pairs).

- Pricing: $0.002–$0.90 USDC on Base, no API keys, no signup
- Agent card: https://data.crestsystems.ai/.well-known/agent.json
- llms.txt: https://data.crestsystems.ai/llms.txt
- l402-services manifest: https://data.crestsystems.ai/.well-known/l402-services

All endpoints return a valid x402 402 and are domain-verified on 402index.io.