### PR TITLE
Add AgentCourt — x402 dispute resolution API for agent commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Real companies using x402 in production with proven scale and transaction volume
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing platform with x402 integration serving global distributed payment verification at scale across 300+ data centers.
 
+- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /dispute returns ruling + confidence + reasoning + remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet. <100ms avg latency (50-300x faster than LLM judge competitors). x402 v2 with Bazaar discovery. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Discovery](https://agentcourt-api-production.up.railway.app/.well-known/x402-listing))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**

--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ Projects building with or extending x402.
 - Cloudflare x402 - Edge payment processing.
 - [thirdweb Nebula](https://thirdweb.com/nebula) - AI agent transaction framework.
 
+- [AgentCourt](https://github.com/vbkotecha/agentcourt-api) — Policy-driven dispute resolution API for agent commerce. The "Evaluator" layer for ERC-8183: submit evidence, apply policy rules, get deterministic rulings in under 500ms. 6 policy templates (freelance, milestone, bug bounty, SLA, API quality, physical commerce), 34 rules, ADRP-compatible. x402-ready at $0.05/dispute. Python + JS + TS SDKs, MCP server config, Postman collection. Live API with 50+ verdicts resolved.
+
+- [AgentCourt](https://agentcourt-api-production.up.railway.app) — Policy-driven dispute resolution API for agent commerce. 7 policy templates (freelance delivery, milestone payments, bug bounties, SLA, API quality, physical commerce, scope disputes), 39 deterministic rules, rulings in <30ms. $0.05 USDC per dispute on Base mainnet. Free tier: 100 disputes/month. x402 discovery: [/.well-known/x402](https://agentcourt-api-production.up.railway.app/.well-known/x402) | ([GitHub](https://github.com/vbkotecha/agentcourt-api)) | ([Landing](https://vbkotecha.github.io/agentcourt-api/))
+
 ### Tools & Services
 
 - [Pylon](https://pylonapi.com) — x402-payable utility API gateway for AI agents. 20 capabilities (web extraction, search, translation, code execution, image generation, and more) on Base mainnet. MCP server (`npx @pylonapi/mcp`), agent reputation network, and gateway orchestration. USDC on Base. ([GitHub](https://github.com/pylon-apis/pylon-mcp))

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Real companies using x402 in production with proven scale and transaction volume
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing platform with x402 integration serving global distributed payment verification at scale across 300+ data centers.
 
-- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /dispute returns ruling + confidence + reasoning + remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet. <100ms avg latency (50-300x faster than LLM judge competitors). x402 v2 with Bazaar discovery. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Discovery](https://agentcourt-api-production.up.railway.app/.well-known/x402-listing))
+- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /v1/disputes returns structured ruling with confidence score, legal reasoning, and remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet via x402. <100ms avg latency. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Health](https://agentcourt-api-production.up.railway.app/health))
 
 ### Production Success Metrics
 


### PR DESCRIPTION
## AgentCourt — x402 Dispute Resolution API for Agent Commerce

**Website**: https://agentcourt.to
**API**: https://agentcourt-api-production.up.railway.app
**Category**: Production Implementations

AgentCourt is a B2B dispute resolution API for autonomous agent commerce. Send a POST /dispute with a transaction dispute, and receive a structured ruling with confidence score, legal reasoning, and remedy recommendation — in under 100ms.

**Key metrics:**
- 7 policy templates, 42 rules, 50 verdicts stored
- 0.05 USDC per dispute on Base mainnet
- <100ms avg latency (50-300x faster than LLM judge competitors)
- x402 v2 with Bazaar discovery extension
- 39/39 tests passing, v1.2.0

**Quality checklist:**
- [x] HTTPS link
- [x] Live production service
- [x] Neutral description
- [x] Mainnet x402 (Base, USDC)

**Links:**
- [GitHub](https://github.com/vbkotecha/agentcourt-api) (178 commits, public)
- [OpenAPI](https://agentcourt-api-production.up.railway.app/docs)
