### PR TITLE
Add Royal Agentic Market Signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Projects building with or extending x402.
 - [x402 Charity](https://allscale-io.github.io/x402charity/) - Open-source middleware for automatic micro-donations via x402. Embed charitable giving into any payment flow — trades, API calls, subscriptions. $0.0001 USDC per event on Base. CLI + web widget. Built by [AllScale Lab](https://allscale.io). ([GitHub](https://github.com/allscale-io/x402charity))
 
 - [x402charity](https://x402charity.com) — Open-source micro-donation server powered by x402. Drop-in Express/Next.js middleware that triggers USDC charity donations on every user action (API call, trade, game move). npm package, CLI, and Vercel-deployable server with built-in dashboard. ([GitHub](https://github.com/allscale-io/x402charity)) ([npm](https://www.npmjs.com/package/x402charity))
+- [Royal Agentic Market Signals](https://nft-alpha-x402.fly.dev) - Paid x402 market intelligence endpoints for AI agents on Base mainnet. Includes NFT collection signal lookup via `POST /api/nft-signal` and equity ticker analysis via `POST /api/analyze-ticker`; both have settled paid calls and Bazaar discovery metadata. USDC payments route through the Coinbase CDP facilitator. ([NFT Alpha](https://nft-alpha-x402.fly.dev/api/nft-signal)) ([TradingAgents](https://tradingagents-x402.fly.dev/api/analyze-ticker))
 ### DeFi & Finance
 
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.


### PR DESCRIPTION
Adds the Royal Agentic Market Signals (NFT Alpha and TradingAgents x402 endpoints) to the curated list of projects.