### PR TITLE
Add Cook County / Chicago Property Data MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 ### Model Context Protocol (MCP)
 
 - [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) - Read-only Base mainnet chain reader purpose-built for x402 payment verification. 11 tools: verify on-chain that a USDC settlement matches a claimed x402 receipt (recipient + amount), parse publisher `/.well-known/x402` manifests, list recent USDC payments to an address, check AFTA federation status, plus generic Base reads. No private keys, no signing, no broadcasts (verification only). Published with cryptographic provenance via GitHub Actions OIDC. `npx -y @tensorfeed/x402-base-mcp`. ([GitHub](https://github.com/RipperMercs/tensorfeed-x402-base-mcp)) ([MCP registry](https://registry.modelcontextprotocol.io/v0/servers/ai.tensorfeed/x402-base-mcp))
+- [Cook County / Chicago Property Data MCP](https://github.com/hyperionxmota/cook-county-property-mcp) - Hosted remote MCP for Cook County / Chicago property records — parcels, recorded sales, building permits, tax assessments, and comparable sales by address or PIN. Pay-per-call via x402 (USDC on Base/Solana). Endpoint: api.ingest0r.com/mcp.
 - **[Vongstaad MCP](https://github.com/VGSTAAD/vongstaad-mcp)** - Quant signal infrastructure. Discovery: vongstaad.com/.well-known/x402.json
 
 


### PR DESCRIPTION
Adds **Cook County / Chicago Property Data MCP** under **Model Context Protocol (MCP)**.

A hosted, remote (streamable-http) MCP server for Cook County / Chicago property records — parcels, recorded sales & deed history, building permits, property-tax assessments, and comparable sales — by street address or 14-digit PIN. Pay-per-call via **x402** (USDC on Base/Solana), no signup/API key.

- MCP endpoint: `https://api.ingest0r.com/mcp`
- Live 402 / HTTP API: `https://api.ingest0r.com` (free sample at `/v1/sample`)
- Also listed on Smithery (`ingest0r/cook-county-property-data`) and the official MCP Registry (`com.ingest0r.api/cook-county-property-data`)

Single line added to the MCP section.