### PR TITLE
Add TerraDeed Scrape API

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Real companies using x402 in production with proven scale and transaction volume
 | Radius        | Production  | Community                  | Instant (<1s)   | Micropayments             |
 
 ### Data & Social APIs
+- [TerraDeed Scrape API](https://api.terradeed.co.uk) - Pay-per-use web scraping and structured JSON extraction. $0.01/$0.05 USDC on Base mainnet. LLM-ready markdown, JS rendering, schema-driven extraction. ([GitHub](https://github.com/terradeed/terradeed-scraper))
 - [EZ-Path](https://ezpath.myezverse.xyz) — Best-execution pay-per-request DEX meta-router. Races 10+ venues (0x, ParaSwap, Aerodrome, Uniswap V3, Curve, Balancer, 1Inch, CoW Swap, Synthetix) concurrently on Base mainnet. Three tiers: basic ($0.03, 0x only), resilient ($0.10, dual-lane race), institutional ($0.50, all venues). Strict agent wallet drain protections with hardcoded toll address validation. x402 v2 USDC on Base. Supports ElizaOS plugin integration. ([Discovery](https://ezpath.myezverse.xyz/.well-known/agent.json)) ([npm](https://www.npmjs.com/package/plugin-ezpath)) ([GitHub](https://github.com/infiniteezverse/ez-agentic-price-path))
 - [Sentinel Intelligence API](https://sentinel-intelligence-api.onrender.com) - Pay-per-brief fintech and AI governance intelligence. BNPL/embedded finance and AI compliance research briefs at $2 USDC; on-demand research on any topic at $10 USDC. CDP-facilitated settlement on Base mainnet. ([Discovery](https://sentinel-intelligence-api.onrender.com/.well-known/x402.json)) ([GitHub](https://github.com/ucsandman/sentinel-api))
 


### PR DESCRIPTION
Adds the TerraDeed Scrape API to the Data & Social APIs section.\n\n- Pay-per-use web scraping ($0.01 USDC) and structured JSON extraction ($0.05 USDC) on Base mainnet\n- LLM-ready markdown output, JS rendering via Playwright, schema-driven extraction via Claude\n- Dual auth: x402 USDC or API keys\n- Open source: github.com/terradeed/terradeed-scraper