### PR TITLE
Add AIServices — Data APIs for AI agents (crypto prices, DeFi yields, IP geo, indicators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Real companies using x402 in production with proven scale and transaction volume
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing platform with x402 integration serving global distributed payment verification at scale across 300+ data centers.
 
+- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /dispute returns ruling + confidence + reasoning + remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet. <100ms avg latency (50-300x faster than LLM judge competitors). x402 v2 with Bazaar discovery. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Discovery](https://agentcourt-api-production.up.railway.app/.well-known/x402-listing))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**

--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ Projects building with or extending x402.
 - Cloudflare x402 - Edge payment processing.
 - [thirdweb Nebula](https://thirdweb.com/nebula) - AI agent transaction framework.
 
+- [AgentCourt](https://github.com/vbkotecha/agentcourt-api) — Policy-driven dispute resolution API for agent commerce. The "Evaluator" layer for ERC-8183: submit evidence, apply policy rules, get deterministic rulings in under 500ms. 6 policy templates (freelance, milestone, bug bounty, SLA, API quality, physical commerce), 34 rules, ADRP-compatible. x402-ready at $0.05/dispute. Python + JS + TS SDKs, MCP server config, Postman collection. Live API with 50+ verdicts resolved.
+
+- [AgentCourt](https://agentcourt-api-production.up.railway.app) — Policy-driven dispute resolution API for agent commerce. 7 policy templates (freelance delivery, milestone payments, bug bounties, SLA, API quality, physical commerce, scope disputes), 39 deterministic rules, rulings in <30ms. $0.05 USDC per dispute on Base mainnet. Free tier: 100 disputes/month. x402 discovery: [/.well-known/x402](https://agentcourt-api-production.up.railway.app/.well-known/x402) | ([GitHub](https://github.com/vbkotecha/agentcourt-api)) | ([Landing](https://vbkotecha.github.io/agentcourt-api/))
+
 ### Tools & Services
 
 - [Pylon](https://pylonapi.com) — x402-payable utility API gateway for AI agents. 20 capabilities (web extraction, search, translation, code execution, image generation, and more) on Base mainnet. MCP server (`npx @pylonapi/mcp`), agent reputation network, and gateway orchestration. USDC on Base. ([GitHub](https://github.com/pylon-apis/pylon-mcp))

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Real companies using x402 in production with proven scale and transaction volume
 - [Coinbase Developer Platform](https://coinbase.com/developer-platform) - Official CDP implementation processing hundreds of thousands of transactions weekly with enterprise-grade reliability and 2-second settlement times.
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing platform with x402 integration serving global distributed payment verification at scale across 300+ data centers.
 
-- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /dispute returns ruling + confidence + reasoning + remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet. <100ms avg latency (50-300x faster than LLM judge competitors). x402 v2 with Bazaar discovery. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Discovery](https://agentcourt-api-production.up.railway.app/.well-known/x402-listing))
+- [AgentCourt](https://agentcourt.to) — B2B dispute resolution API for agent commerce. POST /v1/disputes returns structured ruling with confidence score, legal reasoning, and remedy. 7 policy templates, 42 rules, 50 verdicts stored. $0.05 USDC per dispute on Base mainnet via x402. <100ms avg latency. ([GitHub](https://github.com/vbkotecha/agentcourt-api) | [OpenAPI](https://agentcourt-api-production.up.railway.app/docs) | [Health](https://agentcourt-api-production.up.railway.app/health))
 
 ### Production Success Metrics
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ Projects building with or extending x402.
 - [Token Intelligence API](https://github.com/TKtokyo/token-intel-api) - EVM token security analysis with deterministic risk scoring and natural language summaries via x402 micropayments. Aggregates GoPlus contract, holder, and liquidity data in one request. $0.005 USDC on Base. Cloudflare Workers + Hono. [Live](https://token-intel-api.tatsu77.workers.dev)
 - [DJD AgentScore](https://github.com/djd-agent-score/djd-agent-score) – On-chain reputation scoring API for AI agent wallets. Returns a 0–100 trust score across 5 dimensions (identity, behavior, reliability, viability, capability) from x402 settlement history on Base. Free tier, no signup.
 - [SIBYL](https://sibylcap.com) - Autonomous crypto intelligence agent on Base. Three x402 endpoints: token scoring ($0.05), rug/honeypot detection ($0.02), and builder shipping velocity vs. market cap analysis ($0.10). ERC-8004 registered (Agent #20880). USDC on Base. Discovery: [Agent Card](https://sibylcap.com/8004.json) | [Domain Verification](https://sibylcap.com/.well-known/agent-registration.json)
+- [AIServices](https://api.aiservices.to) — Data APIs for AI agents. 6 endpoints: crypto prices (free), fear-greed index (free), IP geolocation (free), technical indicators ($0.02), DeFi yields ($0.02), URL metadata ($0.01). Free + paid tiers via x402 USDC on Base mainnet.
 
 ### DeFi & Finance
 


### PR DESCRIPTION
## AIServices — Data APIs for AI agents

**Live URL:** https://api.aiservices.to  
**Health:** https://api.aiservices.to/health (200 ✅)

### Endpoints (6)

| Endpoint | Price | Description |
|----------|-------|-------------|
| `GET /v1/prices` | Free | Live crypto prices (BTC, ETH, SOL, XRP, LINK + 20 more) |
| `GET /v1/fear-greed` | Free | Crypto Fear & Greed Index |
| `GET /v1/geo/{ip}` | Free | IP geolocation lookup |
| `GET /v1/indicators/{symbol}` | $0.02 | Technical indicators (RSI, MACD, MA, etc.) |
| `GET /v1/yields` | $0.02 | DeFi yield rates across protocols |
| `GET /v1/metadata` | $0.01 | URL metadata extraction |

### x402 Details
- **Chain:** Base mainnet
- **Settlement:** USDC
- **Payment protocol:** x402 (Coinbase CDP facilitator)
- **x402 manifest:** https://api.aiservices.to/.well-known/x402

### Quick Test
```bash
# Free endpoint
curl https://api.aiservices.to/v1/prices

# Paid endpoint (returns 402 challenge)
curl https://api.aiservices.to/v1/indicators/BTC
```

Added to **Tools & Services** section alongside similar data API providers.
