### PR TITLE
Add Blackwall — pre-signature payment-risk oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ Comprehensive guides for migrating from traditional payment systems to x402.
 
 - [stripe-mcps](https://www.npmjs.com/package/stripe-mcps) - Trust verification + AML sanctions screening before Stripe/x402 payments. Agent identity (ECDSA), 75K+ sanctions entries (UK HMT + OFAC SDN), behavioural spend limits. OWASP MCP Security Cheat Sheet aligned. ([GitHub](https://github.com/razashariff/stripe-mcps))
 - [Crest Verify](https://verify.crestsystems.ai) - Verification tools for x402 endpoints, including conformance checks, service indexing, and signed trust receipts. ([npm](https://npmjs.com/package/@crestdeploymentsystems/verify) | [GitHub](https://github.com/andysalvo/crest))
+- [BLACK_WALL](https://x402.blackwalltier.com) - Pre-signature payment-risk oracle for x402 agents: one call returns GO / HOLD / STOP for paying a counterparty — from OFAC sanctions screening, counterparty reputation, and price-anomaly — plus an independently-verifiable Ed25519 signed receipt. Verdict only, never custody; free under $10 at risk, x402-payable above. Remote MCP tool (`forecast_payment`) + npm (`blackwall-mcp`). ([MCP](https://mcp.blackwalltier.com)) ([demo](https://check.blackwalltier.com/demo)) ([GitHub](https://github.com/bluetieroperations-create/blackwall-mcp))
 Security resources and best practices for x402 implementations.
 
 ### Smart Contract Audits


### PR DESCRIPTION
Adds **Blackwall** under **Agent Verification & Security** — a pre-signature payment-risk oracle for x402.

It returns GO / HOLD / STOP before an agent signs a payment, folding **counterparty reputation**, **price-anomaly** (quoted amount vs the counterparty's own per-payer median, wash-trade-hardened), and **OFAC sanctioned-address screening** into one verdict with a signed receipt. Verdict only, never custody. Live on Base; also an MCP server (`forecast_payment`).

- Live descriptor: https://agent-egress-proxy.onrender.com/.well-known/x402
- Category comparison (vs endpoint-readiness + KYT): https://x402.blackwalltier.com/payment-risk-oracles-compared

Single-line addition, grouped under the existing section per CONTRIBUTING.