### PR TITLE
feat: add b0x402 - AI-powered crypto intel x402 API on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Real companies using x402 in production with proven scale and transaction volume
 
 Major tech companies leveraging x402 in production include **Coinbase** (Native CDP integration, primary facilitator), **Cloudflare** (Edge payment processing infrastructure), **Google** (Agent-to-Agent A2A payment protocol development), **Visa** (Enterprise payment rail exploration), and **thirdweb** (AI agent transaction framework Nebula).
 
+- [b0x402](https://x402-cf-worker.mulberry-boar.workers.dev) - AI-powered crypto intelligence API: meme coin signals, DeFi sentiment, market equilibrium analysis, and wallet profiling on Base. Pay per call in USDC via x402. ($0.01-0.10 USDC/call)
 ## 🛠️ SDKs & Client Libraries
 
 Client libraries for making x402 payments.


### PR DESCRIPTION
## b0x402 — x402-Powered Crypto Intelligence API

**Add b0x402 to Data & Social APIs**

### What is b0x402?
AI-powered crypto intelligence API deployed on Cloudflare Workers, monetized via x402 Payment Required protocol on Base mainnet.

**Endpoints:**
- `/v1/meme-hunter` — Meme coin signals and trend analysis ($0.01 USDC)
- `/v1/defi-sentiment` — DeFi sentiment analysis ($0.01 USDC)
- `/v1/dinalibrium` — Market equilibrium analysis ($0.02 USDC)
- `/v1/wallet-profile` — On-chain wallet profiling ($0.10 USDC)

**Tech Stack:**
- x402 V2 Payment Required (HTTP 402)
- USDC on Base (eip155:8453)
- Cloudflare Workers edge deployment
- Auto-discovery via `.well-known/x402`

### Payment
All calls paid in USDC via x402. No API key required — wallets sign SIWX messages for autonomous agent access.

---
*Submitted by prpo_ai on behalf of B0x70*