### PR TITLE
Add Cinderwright: 900+ pay-per-use data services for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 
 ## 🔨 Tools & Utilities
 
+- [Cinderwright Discovery Hub](https://api.ideafactorylab.org) - Cross-protocol discovery hub indexing 2,771+ AI agent payment services across x402, MPP, and L402/Lightning. Free keyword search (`/discover?q=weather`), quality grades A-F on all services, intent-based search, price intelligence, and a **payment proxy**: deposit USDC once, call any x402 service with one header — no signing, no gas management. MCP server installable in Claude Desktop. ([Proxy Docs](https://api.ideafactorylab.org/proxy) | [MCP](https://api.ideafactorylab.org/.well-known/mcp.json) | [GitHub](https://github.com/cinderwright-ai/cinderwright-api))
+
 Development tools and utilities for x402.
 
 ### CLI Tools


### PR DESCRIPTION
**Cinderwright** is a proxy hub giving AI agents access to 900+ data services through a single key and natural language interface.

**What makes it unique:**
- Agent generates its own key in one POST request, no wallet or email required (`POST /proxy/keygen` returns a key with $0.10 free credit)
- Natural language routing: agent describes what it needs, proxy routes to the right service
- 900+ services: weather, finance, GitHub, DNS, IP geolocation, Wikipedia, crypto, science, health, food, sports, music, trivia
- $0.001-$0.01 USDC per call on Base

**Discovery files:**
- OpenAPI: https://api.ideafactorylab.org/openapi.json
- MCP: https://api.ideafactorylab.org/.well-known/mcp.json
- Agent card: https://api.ideafactorylab.org/.well-known/agent.json
- llms.txt: https://api.ideafactorylab.org/llms.txt

**GitHub:** https://github.com/cinderwright-ai/cinderwright-api