### PR TITLE
feat: add b0xM4 — Meridian Solana DLMM screener to Data & Social APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Real companies using x402 in production with proven scale and transaction volume
 
 Major tech companies leveraging x402 in production include **Coinbase** (Native CDP integration, primary facilitator), **Cloudflare** (Edge payment processing infrastructure), **Google** (Agent-to-Agent A2A payment protocol development), **Visa** (Enterprise payment rail exploration), and **thirdweb** (AI agent transaction framework Nebula).
 
+- [b0x402](https://x402-cf-worker.mulberry-boar.workers.dev) - AI-powered crypto intelligence API: meme coin signals, DeFi sentiment, market equilibrium analysis, and wallet profiling on Base. Pay per call in USDC via x402. ($0.01-0.10 USDC/call)
 ## 🛠️ SDKs & Client Libraries
 
 Client libraries for making x402 payments.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Real companies using x402 in production with proven scale and transaction volume
 Major tech companies leveraging x402 in production include **Coinbase** (Native CDP integration, primary facilitator), **Cloudflare** (Edge payment processing infrastructure), **Google** (Agent-to-Agent A2A payment protocol development), **Visa** (Enterprise payment rail exploration), and **thirdweb** (AI agent transaction framework Nebula).
 
 - [b0x402](https://x402-cf-worker.mulberry-boar.workers.dev) - AI-powered crypto intelligence API: meme coin signals, DeFi sentiment, market equilibrium analysis, and wallet profiling on Base. Pay per call in USDC via x402. ($0.01-0.10 USDC/call)
+- [b0xM4](https://b0xm4-solana-pulse.mulberry-boar.workers.dev) - **Meridian-powered Solana DLMM screener.** Real-time TVL, volume, organic score, smart wallet tracking, token safety, fee/TVL yield ranking. 5 endpoints, $0.0001–0.0005 USDC/call. Payout 7P7w3M9yQs5P... on Solana.
 ## 🛠️ SDKs & Client Libraries
 
 Client libraries for making x402 payments.


### PR DESCRIPTION
## b0xM4 — Meridian-Powered Solana DLMM Screener

**Live endpoint:** https://b0xm4-solana-pulse.mulberry-boar.workers.dev

x402 V2, USDC on Solana. BYPASS OFF — buyers pay.

### Pricing (High-Value Intelligence)

| Endpoint | Price | Intelligence Value |
|----------|-------|--------------------|
| `/v1/smart-wallets` | **$5.00/call** | KEY deploy signal — strongest conviction factor in Meridian's 2-month screening cycles |
| `/v1/token-safety` | **$3.00/call** | Would have caught FLKR-SOL rug flags before deploy |
| `/v1/pool-screener` | **$3.00/call** | Full Meridian threshold engine — all user-config filters applied |
| `/v1/dlmm-pools` | **$2.00/call** | Foundational pool list with TVL/volume/organic metrics |
| `/v1/yield-hunter` | **$2.00/call** | Fee/TVL efficiency ranking — target >8% |

**Network:** Solana mainnet
**Payment:** USDC (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
**Payout:** `7P7w3M9yQs5PCH2WbfmMxVWnkrobVsq1ARZBFfJ5W5zN`

This is Meridian's core intelligence distilled into callable APIs — not commodity data.