### PR TITLE
Add SuVerse Pay (production x402 API catalog, ~490 endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [GoldBean API](https://goldbean-api.xyz) — 146+ AI endpoints including Baidu OCR, Translation, TTS, LLM Chat with x402 micropayments on Base. From ### Production Success Metrics.01/call for premium AI. MCP server at [mcpize.com/mcp/goldbean](https://mcpize.com/mcp/goldbean). ([GitHub](https://github.com/wuzenghai616-lang/goldbean))
 
+- [SuVerse Pay](https://suverse-pay.suverse.io) - Payment gateway + API catalog with ~490 paid endpoints on one origin: crypto market data, Polymarket smart-money verdicts, token-safety forensics (Base + Solana), macro/gov datasets, and an x402 endpoint liveness probe. $0.05–$0.75 USDC per call, multi-chain settlement (Base + Solana + Cosmos Noble) via a self-hosted facilitator, no API keys or signup. ([OpenAPI](https://proxy.suverse.io/openapi.json) | [Catalog](https://suverse-pay.suverse.io/catalog) | [MCP](https://www.npmjs.com/package/@suverselabs/mcp-server) | [Buyer SDK](https://www.npmjs.com/package/@suverselabs/x402-client))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
## What
Adds **SuVerse Pay** to *Production Implementations → High-Volume Production Deployments*.

## Why it qualifies
- Live production catalog: ~490 paid x402 endpoints on one origin (`proxy.suverse.io/v1/data/<slug>`), OpenAPI 3.1 at [proxy.suverse.io/openapi.json](https://proxy.suverse.io/openapi.json)
- Multi-chain settlement in production: USDC on Base + Solana + Cosmos Noble, via a self-hosted facilitator
- Flagship verdict products (Polymarket smart-money sheet, Base token forensics, Solana token entry verdict, market regime verdict, x402 liveness probe) at $0.25–$0.75; long tail of data endpoints at $0.05–$0.10
- No API keys or signup; buyer tooling on npm: [@suverselabs/mcp-server](https://www.npmjs.com/package/@suverselabs/mcp-server), [@suverselabs/x402-client](https://www.npmjs.com/package/@suverselabs/x402-client)

One entry, one category, links tested.