### PR TITLE
Add paysh-agent-recipes to Example Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Full working examples and templates.
 - [Fetch Client](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/fetch) - Fetch API wrapper demo.
 - Python Requests - Python client example.
 - [agent-starter-x402](https://github.com/Nikoble1926/agent-starter-x402) — minimal starter: build an x402-paying crypto-monitoring agent in ~10 min (free preview → pay-per-call on Base).
+- [paysh-agent-recipes](https://github.com/nickisanders/paysh-agent-recipes) - Copy-pasteable recipes for AI agents that pay per request over pay.sh (Solana Foundation and Google Cloud), no API keys. Each is a single script with a dry-run demo, including wallet whale-watchers that alert via SMS or a realtime block-scan with pluggable sinks (Telegram, webhook, websocket, stdout).
 
 ## 🎨 Use Cases & Patterns
 


### PR DESCRIPTION
## Add paysh-agent-recipes

**What:** A small open-source library of copy-pasteable AI agent recipes built on pay.sh (per-request USDC micropayments over x402, no API keys). Two recipes so far: a cron wallet whale-watcher that SMS-alerts via Twilio, and a realtime block-scan variant with ~one-block latency and pluggable alert sinks (Telegram, webhook, websocket, stdout).

**Why:** Gives x402 developers a working, minimal reference for building agents that pay per request over pay.sh, including an on-chain-data use case. Each recipe is a single script with a dry-run demo mode, an example driver, and a README, so it runs end-to-end before spending anything.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Example Applications → Client Examples