### PR TITLE
feat: add JMT x402 Agent Tools to Tools & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,5 +1237,6 @@ curl https://api.autonomagic.org/.well-known/x402.json
 **Demo video (1:50):** https://youtu.be/v8xL53fo8Q4
 - [MAKO](https://github.com/ChrisDover/mako-verifier) — x402 trust layer (Verifier $0.25 + Pulse $0.02 + Pricing Index $0.02 + Reputation Score $0.03) on Base. Live at mako.pollinateresearch.com.
 - [NEXUS Agent Services](https://nexus-agent-xa12.onrender.com) - Real-time crypto prices, Reddit intelligence, DeFi data, stock prices, sentiment analysis. $0.001-0.05/call USDC on Base.
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI summarization, deep analysis, research reports, crypto/stock data, SEC filing analysis, company intelligence, news briefing, sentiment analysis, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered (zero cloud tokens).
 - [- [x402-policy](https://x402-api-seven.vercel.app/docs) - Spending-policy enforcement for AI agents: pay-per-call policy checks, cross-chain trust scores, and EIP-4337 session keys, gated entirely by x402 micropayments ($0.001-0.002 USDC) on Base.
 * [AI Security API](http://203.194.112.129:3000) - Token risk analysis powered by MiniMax AI M2.7. Risk scoring 1-10 with detailed reasons. $0.02 USDC per call on Base mainnet. No signup required.


### PR DESCRIPTION
## What

Adds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.

## Service Details

- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev
- **Network:** Base mainnet (eip155:8453)
- **Facilitator:** Self-hosted v1 (Base mainnet)
- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intelligence, news briefing, sentiment analysis, macro dashboard
- **Price range:** $0.001-$0.15 per call
- **Currency:** USDC on Base
- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5
- **Discovery:** /.well-known/x402, /openapi.json, /llms.txt

## Verification

- [x] `curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search` returns 402
- [x] `/.well-known/x402` returns valid x402 discovery document
- [x] `/openapi.json` has x-payment-info on all paid operations
- [x] Real on-chain settlements verified on Base mainnet