### PR TITLE
Add InboxPolicy to AI Agent Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,8 @@ AI-powered research and translation services for the Asian market — no other x
 
 - [Anicca](https://anicca-x402.netlify.app) — Autonomous Buddhist AI agent on Base. Self-operating LLM that funds its own compute by selling its own routes via x402. Five priced endpoints: `/qa` ($0.003 Buddhist Q&A), `/research` ($0.05 deep research with citations), `/x-post` ($0.01 tweet draft), `/pdf/:slug` ($5–29 premium PDFs), `/build` ($50–2000 custom autonomous builds). USDC on Base. MIT-licensed, no human in the loop. ([Discovery](https://anicca-x402.netlify.app/.well-known/x402)) | ([GitHub](https://github.com/Daisuke134/anicca-oss)) | ([Autonomy spec](https://github.com/Daisuke134/anicca-oss/blob/main/docs/specs/ANICCA_TRUE_AUTONOMY_SPEC.md))
 
+- [InboxPolicy](https://inboxpolicy.com) - Send-decision email verification for AI agents. One call returns an action — send / send_with_caution / review / retry_later / avoid — with confidence and SMTP/DNS evidence, instead of a raw status field. x402 pay-per-call at $0.01 USDC on Base (single or bulk: one payment per batch of up to 5,000 emails), no account. Hosted MCP server at `https://mcp.inboxpolicy.com` exposes decide_send/verify_email/batch tools. [Docs](https://inboxpolicy.com/docs) | [Benchmark](https://inboxpolicy.com/benchmark) | [llms.txt](https://inboxpolicy.com/llms.txt)
+
 
 ## 🔨 Tools & Utilities
 


### PR DESCRIPTION
Adds **InboxPolicy** to the 🤖 AI Agent Integration section.

InboxPolicy is a send-decision email verification API for AI agents: one call returns an action — `send` / `send_with_caution` / `review` / `retry_later` / `avoid` — with confidence and SMTP/DNS evidence, instead of a raw status field.

- x402 pay-per-call at $0.01 USDC on Base (single **or** bulk — one payment per batch of up to 5,000 emails), no account needed.
- Hosted MCP server (`https://mcp.inboxpolicy.com`) exposes `decide_send` / `verify_email` / batch tools for agent integration.
- Public examples repo: https://github.com/sorcerai/inboxpolicy-examples

One entry added at the end of the AI Agent Integration section; format matched to the existing bullets.