### PR TITLE
Add GlobalRules to Ecosystem Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,8 +821,7 @@ Connect with the x402 community.
   
 - [SunfishLoop](https://sunfishloop.com) — Open-source agent-to-agent social network with built-in crypto tipping (ETH, SOL, BTC). Agents discover each other, collaborate, and tip on-chain; over $200 in cross-agent tips settled on mainnet. OpenAPI + Agent Protocol. ([GitHub](https://github.com/sunfishloop/sunfishloop))
 - [Orbis API Marketplace](https://orbisapi.com) - x402-native API marketplace with 1,000+ APIs at $0.01/call via USDC on Base. Built for AI agents — weather, financial data, text processing, crypto data. No API keys required.
-- [GlobalRules](https://globalrules.org) — Per-country practical facts API for AI agents: VAT/GST rates, public holidays, tipping, plugs & voltage, visas, minimum wage — ~50 topics across 54 countries, $0.005–0.01/call. x402/USDC on Base.
-Projects building with or extending x402.
+- [GlobalRules](https://globalrules.org) — Per-country practical facts API for AI agents (VAT/GST, public holidays, tipping, plugs, visas, minimum wages — ~50 topics across 70+ countries, growing daily). Pay-per-call via x402 on Base, live on the x402 Bazaar.
 
 ### Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ Connect with the x402 community.
   
 - [SunfishLoop](https://sunfishloop.com) — Open-source agent-to-agent social network with built-in crypto tipping (ETH, SOL, BTC). Agents discover each other, collaborate, and tip on-chain; over $200 in cross-agent tips settled on mainnet. OpenAPI + Agent Protocol. ([GitHub](https://github.com/sunfishloop/sunfishloop))
 - [Orbis API Marketplace](https://orbisapi.com) - x402-native API marketplace with 1,000+ APIs at $0.01/call via USDC on Base. Built for AI agents — weather, financial data, text processing, crypto data. No API keys required.
+- [GlobalRules](https://globalrules.org) — Per-country practical facts API for AI agents: VAT/GST rates, public holidays, tipping, plugs & voltage, visas, minimum wage — ~50 topics across 54 countries, $0.005–0.01/call. x402/USDC on Base.
 Projects building with or extending x402.
 
 ### Infrastructure


### PR DESCRIPTION
Adds GlobalRules to the Ecosystem Projects section.

GlobalRules is a live country-facts micro-data API for AI agents: VAT/GST rates, public holidays, tipping customs, plug types & voltage, visa requirements, minimum wage and ~50 topics per country, covering 54 countries. Priced per call ($0.005-0.01) via x402/USDC on Base.

- Site: https://globalrules.org (llms.txt available)
- - API discovery (free endpoint): https://globalrules-api.onrender.com/