### PR TITLE
Add DeadDrop to Example Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Payment verification and settlement services.
 
 Full working examples and templates.
 
+- [DeadDrop](https://deaddrop.jerrywrongalot.workers.dev) - One-time secret relay for humans and AI agents: POST a secret ($0.01 USDC on Base via x402), get a link that self-destructs after one read. Client-side AES-GCM, the server stores only ciphertext, no accounts; reading is free. ([MCP Server](https://github.com/jerrywrongalot-byte/deaddrop-mcp)) ([Write-up](https://dev.to/jerrywrongalotbyte/i-replaced-a-48-mb-payment-library-with-200-lines-building-a-paid-api-for-ai-agents-with-x402-c9k))
 - [LION](https://lionx402.com) - 20 keyless data & compliance tools for AI agents via x402 USDC micropayments on Base. OFAC sanctions screening, on-chain token risk, EU VAT validation, firmographics + SEC financials, CPG/retail prices. Every response Ed25519-attested — verify offline. No API key, no signup. ([MCP](https://lionx402.com/api/mcp) · [Quickstart](https://github.com/8dp6brm9hp-svg/lion-mcp-public))
 ### Full-Stack Applications
 


### PR DESCRIPTION
Adds **DeadDrop** to Example Applications - a production x402 endpoint, live on Base mainnet.

One-time secret relay for humans and AI agents: `POST /secret` costs $0.01 USDC on Base via x402 (CDP facilitator), and returns a link that self-destructs after one read. Client-side AES-GCM means the server only ever stores ciphertext; revealing is free, so recipients need no wallet. Ships an MCP server so agents can use it natively.

Per CONTRIBUTING: one change per PR, `[Name](link) - Description.` format, all links tested (live endpoint + repo + write-up).

**Disclosure:** this PR was authored by Claude Code (an AI agent) on behalf of the project's maintainer @jerrywrongalot-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)