### PR TITLE
Add AgentFund to Ecosystem Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,6 +819,7 @@ Connect with the x402 community.
 
 - [Fundchain](https://fundchain.ai) - Crypto crowdfunding for AI agents. MCP-native, x402 compatible. AI agents create campaigns and accept ETH/USDC donations autonomously. [MCP Server](https://github.com/fundchainteam/fundchain-mcp) | [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=fundchain)
   
+- [AgentFund](https://agentfund.online) - Fundraising infrastructure for AI agents on Solana. Agents register on-chain identities, launch campaigns, donate via x402 (the payment is the auth, no API keys), vote on milestone releases, and build on-chain reputation; funds sit in program-derived escrow until contributor votes clear. Live on devnet with real settled x402 USDC donations. ([MCP Server](https://github.com/agentIgris/agentfund/tree/main/mcp)) | ([GitHub](https://github.com/agentIgris/agentfund))
 - [SunfishLoop](https://sunfishloop.com) — Open-source agent-to-agent social network with built-in crypto tipping (ETH, SOL, BTC). Agents discover each other, collaborate, and tip on-chain; over $200 in cross-agent tips settled on mainnet. OpenAPI + Agent Protocol. ([GitHub](https://github.com/sunfishloop/sunfishloop))
 - [Orbis API Marketplace](https://orbisapi.com) - x402-native API marketplace with 1,000+ APIs at $0.01/call via USDC on Base. Built for AI agents — weather, financial data, text processing, crypto data. No API keys required.
 Projects building with or extending x402.


### PR DESCRIPTION
AgentFund is fundraising infrastructure for AI agents on Solana: agents register on-chain identities, launch campaigns, donate via x402 (the payment itself is the auth — no API keys), vote on milestone releases weighted by contribution, and build verifiable on-chain reputation. Escrowed funds sit in a program-derived account and release only after contributor votes clear.

Live on Solana devnet today with real settled x402 USDC donations (end-to-end, ~2.5s settlement). Adds one entry to Ecosystem Projects, next to the existing agent-crowdfunding entry (Fundchain), following the repo's `[Name](link) - description` format.

- Site: https://agentfund.online
- MCP server: https://github.com/agentIgris/agentfund/tree/main/mcp
- Repo: https://github.com/agentIgris/agentfund