### PR TITLE
Add kr-market-briefing to Ecosystem Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,6 +941,7 @@ Projects building with or extending x402.
 - [Agent402 Marketplace](https://agent402.app) - Multi-chain agent marketplace + identity layer. 7,900+ services indexed from CDP Bazaar + PayAI, x402 V1+V2 payments E2E-proven on 13 networks across 3 facilitators (Coinbase CDP, PayAI, Blocky402), 5 identity methods (ERC-8004, did:ethr, did:hedera, did:sol, SATI). Agent402 Mode chat overlay searches, executes, and pays in one flow. MCP, A2A, and OASF discovery endpoints per agent. ([GitHub](https://github.com/EnvisionBlockchain/multi-chain-agent-identity))
 
 - [Secant Agent Research Pack](https://agentic.secantoutreach.com/agent-research) - MCP-first paid web research for autonomous agents. Search, page extraction, normalized JSON, citations, and diff monitoring over x402 with Base USDC. Web research endpoints are $0.001-$0.012 per call; Codex audit is a separate $0.25 endpoint. ([Manifest](https://agentic.secantoutreach.com/.well-known/x402.json) | [OpenAPI](https://agentic.secantoutreach.com/openapi.yaml) | [MCP wrapper](https://github.com/jnilrac/secant-agent-research-mcp))
+- [kr-market-briefing](https://kr-intel-agent-production.up.railway.app/api/briefing) - Korea crypto market intelligence: kimchi premium, KR exchange prices, Korean sentiment + global macro synthesized into decision-ready briefings. $0.35 USDC per call on Base. ([Discovery](https://kr-intel-agent-production.up.railway.app/openapi.json))
 
 
 ### Data & Social APIs


### PR DESCRIPTION
## Summary
Adds **kr-market-briefing** to the Ecosystem Projects → Tools & Services section.

- Korea crypto market intelligence: kimchi premium, KR exchange prices, Korean sentiment + global macro synthesized into decision-ready briefings
- $0.35 USDC per call on Base (x402)
- Endpoint: https://kr-intel-agent-production.up.railway.app/api/briefing
- Discovery: https://kr-intel-agent-production.up.railway.app/openapi.json

## Checklist
- [x] One change per PR
- [x] Follows the `[Resource Name](link) - Description.` format
- [x] Added at the bottom of the relevant category (Tools & Services)
- [x] Links verified working