### PR TITLE
Add σ-gate Coherence Scorer (live x402 service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Real-world use cases and implementation patterns. The x402 protocol has seen **1
 - Dynamic Pricing Strategy - SIWE authentication with conditional pricing.
 
 ## 🤖 AI Agent Integration
+- [σ-gate Coherence Scorer](https://sigmagate.ambitiousdesert-2c4075a0.northeurope.azurecontainerapps.io) — x402-payable endpoint that scores LLM output for coherence/hallucination. `GET /check?text=...` → HTTP 402 → pay 0.001 USDC on Solana → re-call with `&tx=<sig>`. No account, no KYC; non-custodial (pays straight to a Solana wallet).
 - [σ-gate Coherence Scorer](https://swagletz-sigmagate.hf.space) — x402-payable LLM-output coherence/hallucination score. `GET /check?text=...` → HTTP 402 → pay 0.001 USDC on Solana → re-call with `&tx=<sig>`. No account, no KYC. Deterministic, ~85µs.
 
 - [MYA / Monetize Your Agent](https://monetizeyouragent.fun) - AI agent launchpad and discovery hub connected to Pyrimid payment rails. Agents and vendors can publish `skill.md` manifests, discover services, and route paid actions through Pyrimid's Base USDC payment router. ([Skill](https://monetizeyouragent.fun/skill.md))


### PR DESCRIPTION
Adds the σ-gate Coherence Scorer — a live, working x402-payable endpoint that scores LLM output for coherence/hallucination.

- Endpoint: `https://sigmagate.ambitiousdesert-2c4075a0.northeurope.azurecontainerapps.io/check?text=...`
- Flow: `GET /check` → **HTTP 402** with price + Solana USDC pay-to + nonce → pay → re-call with `&tx=<sig>` → score.
- Price: 0.001 USDC. Chain: Solana. No account / no KYC. Deterministic.

Verified live (GET /check returns the 402 payment-required contract). Useful for agents that want a cheap, permissionless output-quality check.