### PR TITLE
Add Studio X

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [GoldBean API](https://goldbean-api.xyz) — 146+ AI endpoints including Baidu OCR, Translation, TTS, LLM Chat with x402 micropayments on Base. From ### Production Success Metrics.01/call for premium AI. MCP server at [mcpize.com/mcp/goldbean](https://mcpize.com/mcp/goldbean). ([GitHub](https://github.com/wuzenghai616-lang/goldbean))
 
+- [Studio X](https://www.studio-x.cc) - Production image and video generation API with 11 models, per-generation x402 pricing, and USDC settlement on Base. ([OpenAPI](https://www.studio-x.cc/openapi.json) | [x402 discovery](https://www.studio-x.cc/.well-known/x402))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
## Add Studio X

Adds Studio X to the production implementations section.

- Production x402 image and video generation API
- 11 models across four paid routes
- USDC settlement on Base
- Public OpenAPI and `/.well-known/x402` discovery documents

All linked endpoints are live and accessible without an account for discovery.