### PR TITLE
Add IntentFence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,7 @@ x402 v2. MCP server on npm. Dataset actively growing.
 - [Paybound](https://github.com/pando-b/paybound) - Open-source spending controls for AI agents making x402 payments. Per-agent budgets, time-windowed limits, circuit breakers, and full audit trail. Drop-in `@x402/fetch` replacement. MIT licensed.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforces daily spending limits, per-transaction caps, recipient whitelists, and rate limiting without holding private keys.
 - [ICME Labs](https://docs.icme.io) - Formal verification for AI agent actions using the ARc paper approach. Natural language policies compile to SMT-LIB formal logic, checked by an SMT solver — SAT = allowed, UNSAT = blocked. Wrapped in zero knowledge proofs for sub-1s verification, private policies, and  cryptographic audit trails per decision. 99%+ soundness under adversarial pressure. $0.10 USDC per check on Base, no account needed. Live demo policy available. 
+- [IntentFence](https://github.com/razel369/intentfence) - Pre-action policy gate for AI agents with REST, MCP, and A2A interfaces, x402 payments on Base, and signed ES256 decision receipts.
 
 ## 🔗 Related Protocols
 


### PR DESCRIPTION
## Add IntentFence

**What:** Adds IntentFence, an open-source pre-action policy gate for AI agents with REST, MCP, A2A, x402 payments on Base, and signed decision receipts.

**Why:** It gives x402 developers a policy-enforcement primitive for checking autonomous actions and payments before execution.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Spending Controls & Policy Enforcement