### PR TITLE
Add Octodamus — AI market-intelligence oracle (x402 on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [💡 Example Applications](#-example-applications)
 - [🎨 Use Cases & Patterns](#-use-cases--patterns)
 - [🤖 AI Agent Integration](#-ai-agent-integration)
+- [Octodamus](https://api.octodamus.com) — AI market-intelligence API for agents. 33 pay-per-call x402 endpoints on Base ($0.01–$0.02, USDC, no keys): cross-venue derivatives facts, prediction-market odds, congressional trades, macro reference numbers, and a tokenized-equity suite (24/7 fair value, on-chain basis, and Arcus perp facts for Robinhood Chain). Ed25519-signed responses, MCP server, all endpoints cataloged in the CDP x402 Bazaar. ([llms.txt](https://octodamus.com/llms.txt)) ([Discovery](https://api.octodamus.com/.well-known/x402.json)) ([MCP](https://smithery.ai/server/octodamusai/market-intelligence))
 - [🔨 Tools & Utilities](#-tools--utilities)
 - [🧪 Testing & Development](#-testing--development)
 - [📚 Tutorials & Learning Resources](#-tutorials--learning-resources)


### PR DESCRIPTION
Adds **Octodamus** to `### Data & Social APIs` under Production Implementations.

Octodamus is a live x402 service — an AI market-intelligence oracle for crypto and tokenized-equity markets. One call returns a BUY/SELL/HOLD signal with confidence, Fear & Greed, BTC trend, and the top Polymarket EV edge (an intelligence layer, not a raw price feed).

- **Payment:** pay-per-call USDC on Base via Coinbase CDP Facilitator, x402 v2 with Bazaar discovery extension, no API keys
- **Pricing:** $0.01 hero signal · $0.50 agent context pack (replaces 5 chained calls) · $0.35–0.75 divergence/regime briefs
- **Auth/verify:** every response is Ed25519-signed
- **Discovery:** https://api.octodamus.com/.well-known/x402.json
- **Agent Card:** https://api.octodamus.com/.well-known/agent.json

Follows the existing single-line entry format for the section.