### PR TITLE
Add VulnFeed (pay-per-call CVE/EPSS vulnerability intelligence via x402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ and developers. 511 protocols tracked ($553B TVL), 813 incidents indexed ($43.2B
 per-factor explainability, live exploit alerts, and audit findings. $0.02–$0.15/call via 
 x402 v2. MCP server on npm. Dataset actively growing.
 - [Agent Income](https://clearance.nauti-labs.com/agent-income) - Paid readiness and monetization review endpoints for agent, API, and MCP payment flows. `POST /agent-income/audit` ($49), `POST /agent-income/review` ($199), and `POST /agent-income/blueprint` ($499) return HTTP 402 payment requirements before fulfillment; `POST /agent-income/custom-quote` handles $1500+ implementation scopes. Payment is required before work and fulfillment requires Clearance approval. ([Audit](https://clearance.nauti-labs.com/agent-income/audit) | [Review](https://clearance.nauti-labs.com/agent-income/review) | [Blueprint](https://clearance.nauti-labs.com/agent-income/blueprint) | [Custom Quote](https://clearance.nauti-labs.com/agent-income/custom-quote))
+- [VulnFeed](https://vulnfeed.novadyne.ai) - Pay-per-call CVE and EPSS vulnerability intelligence for AI agents. Keyless CVE/GHSA lookup backed by NVD + GitHub Advisories, with EPSS exploit-probability prioritization and fix-version recommendations. $0.002 USDC per call on Base. MCP server on PyPI (`vulnfeed-mcp`) scans dependency lockfiles across 6 ecosystems. ([GitHub](https://github.com/novadyne-hq/vulnfeed-mcp)) ([Discovery](https://agent-worker.infai-tech-corporation.workers.dev/.well-known/x402))
 
 ### Spending Controls & Policy Enforcement
 


### PR DESCRIPTION
Adds **VulnFeed** to *Security & Audits → Security Monitoring*.

VulnFeed is a live pay-per-call CVE/EPSS vulnerability-intelligence feed for AI agents: keyless CVE/GHSA lookup backed by NVD + GitHub Advisories, with EPSS exploit-probability prioritization and fix-version recommendations — $0.002 USDC per call on Base via x402 (v2, CDP facilitator). It also ships an MCP server on PyPI (`vulnfeed-mcp`) that scans dependency lockfiles across 6 ecosystems.

Why it fits this section: it is a working, settling x402 security-data endpoint in the same class as the other monitoring/intelligence entries here (live 402 challenge at the Discovery link; on x402scan; ERC-8004 agent identity minted on Base).

- Site: https://vulnfeed.novadyne.ai
- GitHub: https://github.com/novadyne-hq/vulnfeed-mcp
- Discovery: https://agent-worker.infai-tech-corporation.workers.dev/.well-known/x402

Single-line addition, follows the `[Name](link) - Description.` format; all links verified live.