### PR TITLE
Add Ad Agency for Agents — AOP Store (77 x402-payable offers + natural-language discovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [GoldBean API](https://goldbean-api.xyz) — 146+ AI endpoints including Baidu OCR, Translation, TTS, LLM Chat with x402 micropayments on Base. From ### Production Success Metrics.01/call for premium AI. MCP server at [mcpize.com/mcp/goldbean](https://mcpize.com/mcp/goldbean). ([GitHub](https://github.com/wuzenghai616-lang/goldbean))
 
+- [Ad Agency for Agents — AOP Store](https://adagencyforagents.com) — 77 agent-payable digital products (books, self-paced courses, guided meditations, archetype readings) with x402 checkout in USDC on Base ($7–$997/item). Natural-language discovery: `POST` [`/v0/discover`](https://index.adagencyforagents.com/v0/discover) `{intent}` → ranked, signature-verified offers; full catalog at [`/v0/offers`](https://index.adagencyforagents.com/v0/offers). Authors of the **Agent Offer Protocol (AOP v0)**. On-chain-verified agent reputation at [repforagents.com](https://repforagents.com) and $AGNT settlement at [byagentforagent.com](https://byagentforagent.com). ([Discovery](https://adagencyforagents.com/.well-known/aop.json) | [llms.txt](https://adagencyforagents.com/llms.txt) | [Index API](https://index.adagencyforagents.com/))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [Ad Agency for Agents — AOP Store](https://adagencyforagents.com) — 77 agent-payable digital products (books, self-paced courses, guided meditations, archetype readings) with x402 checkout in USDC on Base ($7–$997/item). Natural-language discovery: `POST` [`/v0/discover`](https://index.adagencyforagents.com/v0/discover) `{intent}` → ranked, signature-verified offers; full catalog at [`/v0/offers`](https://index.adagencyforagents.com/v0/offers). Authors of the **Agent Offer Protocol (AOP v0)**. On-chain-verified agent reputation at [repforagents.com](https://repforagents.com) and $AGNT settlement at [byagentforagent.com](https://byagentforagent.com). ([Discovery](https://adagencyforagents.com/.well-known/aop.json) | [llms.txt](https://adagencyforagents.com/llms.txt) | [Index API](https://index.adagencyforagents.com/))
 
+- [Ad Agency for Agents — AOP Store](https://adagencyforagents.com) — 77 agent-payable digital products (books, courses, guided meditations, archetype readings) with x402 checkout in USDC on Base ($7–$997/item). Natural-language discovery: `POST` [`/v0/discover`](https://index.adagencyforagents.com/v0/discover) `{intent}` → ranked, signature-verified offers; catalog at [`/v0/offers`](https://index.adagencyforagents.com/v0/offers). Authors of the **Agent Offer Protocol (AOP v0)**. On-chain-verified agent reputation at [repforagents.com](https://repforagents.com) and $AGNT settlement at [byagentforagent.com](https://byagentforagent.com). ([Discovery](https://adagencyforagents.com/.well-known/aop.json) | [llms.txt](https://adagencyforagents.com/llms.txt))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
Adds **Ad Agency for Agents / AOP Store** to Production Implementations.

- 77 agent-payable digital products with x402 checkout (USDC on Base, $7–$997/item)
- Natural-language discovery API: `POST /v0/discover {intent}` → ranked, signature-verified offers ([live](https://index.adagencyforagents.com/))
- Authors of the Agent Offer Protocol (AOP v0)
- On-chain-verified agent reputation ([repforagents.com](https://repforagents.com)) + $AGNT settlement ([byagentforagent.com](https://byagentforagent.com))
- Fully self-describing: [llms.txt](https://adagencyforagents.com/llms.txt), [/.well-known/aop.json](https://adagencyforagents.com/.well-known/aop.json)

All links live. Thanks for maintaining the list!