### PR TITLE
Add mdapi + chainpulse (two live x402 APIs) to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Real companies using x402 in production with proven scale and transaction volume
 - [ToolSnap MCP](https://mcp.toolsnap.app) — 28 context-efficient MCP tools for AI agents: web extraction, data processing, SEO, image processing. Flagship `fetch_extract` benchmarked at 98.1% token reduction (53,820 → 2,001 tokens, saving ~$0.156/call at Sonnet pricing). x402 v2 on Base with EIP-3009 `transferWithAuthorization`. Dual payment: pay-per-call $0.02 USDC or prepaid ($0.50 deposit → $0.01/call off-chain, no per-call gas, no 402 round-trip). 27 tools free, no API keys. Cloudflare Workers edge-native, 0ms cold start. Glama A rated. ([GitHub](https://github.com/icosaedro-git/toolsnap-mcp) | [Glama](https://glama.ai/mcp/connectors/app.toolsnap/toolsnap-mcp))
 
 - [Veles Finance Agent](https://veles-finance-gateway.fly.dev) - Production FastAPI + LangGraph financial analysis service with x402 paywall on Base. Provides SEC 10-K extraction, stock due diligence, and Kelly Criterion at $0.01-$0.05 USDC per request. ([Discovery](https://veles-finance-gateway.fly.dev/.well-known/x402))
+- [mdapi](https://md.fastdb.in) - HTML-to-Markdown API for AI agents: POST a URL or raw HTML, get clean LLM-ready Markdown (Readability article extraction, tables preserved); POST /extract returns structured JSON (title, byline, links, images, meta). $0.005 USDC per call via x402 on Base, no signup, no API key. ([OpenAPI](https://md.fastdb.in/openapi.json))
 ### Production Success Metrics
 
 **Key Performance Indicators:**

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [Veles Finance Agent](https://veles-finance-gateway.fly.dev) - Production FastAPI + LangGraph financial analysis service with x402 paywall on Base. Provides SEC 10-K extraction, stock due diligence, and Kelly Criterion at $0.01-$0.05 USDC per request. ([Discovery](https://veles-finance-gateway.fly.dev/.well-known/x402))
 - [mdapi](https://md.fastdb.in) - HTML-to-Markdown API for AI agents: POST a URL or raw HTML, get clean LLM-ready Markdown (Readability article extraction, tables preserved); POST /extract returns structured JSON (title, byline, links, images, meta). $0.005 USDC per call via x402 on Base, no signup, no API key. ([OpenAPI](https://md.fastdb.in/openapi.json))
+- [chainpulse](https://md.fastdb.in/pulse/) - Real-time crypto market data API for AI agents: POST /price (aggregated USD spot prices with confidence score, incl. Base ERC-20s by address), POST /gas (live gas + USD transfer cost on Ethereum/Base/Arbitrum/Optimism/Polygon), POST /tvl (DeFi protocol TVL via DefiLlama slugs). $0.001 USDC per call via x402 on Base, no signup, no API key. ([OpenAPI](https://md.fastdb.in/pulse/openapi.json))
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
## What this adds

Two entries in **Production Implementations**, both live paid x402 services from the same operator:

**[mdapi](https://md.fastdb.in)** — HTML-to-Markdown conversion API for AI agents.
- `POST /md` — URL or raw HTML in, clean LLM-ready Markdown out (Readability article extraction, tables preserved)
- `POST /extract` — structured JSON (title, byline, excerpt, links, images, meta)
- $0.005 USDC per call via x402 on Base mainnet, settled through the Coinbase CDP facilitator. No signup, no API key.

**[chainpulse](https://md.fastdb.in/pulse/)** — real-time crypto market data for agents.
- `POST /price` (aggregated USD spot prices with confidence score), `POST /gas` (5 chains, USD transfer cost), `POST /tvl` (DefiLlama slugs)
- $0.001 USDC per call via x402 on Base. No signup, no API key.

Both are verifiable right now: any `POST` without an `X-PAYMENT` header returns the standard 402 payment-requirements body, and both are indexed in the CDP Bazaar / x402-list.com.