### PR TITLE
Add BridgeNode to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Real companies using x402 in production with proven scale and transaction volume
 - [ToolSnap MCP](https://mcp.toolsnap.app) — 28 context-efficient MCP tools for AI agents: web extraction, data processing, SEO, image processing. Flagship `fetch_extract` benchmarked at 98.1% token reduction (53,820 → 2,001 tokens, saving ~$0.156/call at Sonnet pricing). x402 v2 on Base with EIP-3009 `transferWithAuthorization`. Dual payment: pay-per-call $0.02 USDC or prepaid ($0.50 deposit → $0.01/call off-chain, no per-call gas, no 402 round-trip). 27 tools free, no API keys. Cloudflare Workers edge-native, 0ms cold start. Glama A rated. ([GitHub](https://github.com/icosaedro-git/toolsnap-mcp) | [Glama](https://glama.ai/mcp/connectors/app.toolsnap/toolsnap-mcp))
 
 - [Veles Finance Agent](https://veles-finance-gateway.fly.dev) - Production FastAPI + LangGraph financial analysis service with x402 paywall on Base. Provides SEC 10-K extraction, stock due diligence, and Kelly Criterion at $0.01-$0.05 USDC per request. ([Discovery](https://veles-finance-gateway.fly.dev/.well-known/x402))
+- [BridgeNode](https://bridgenode.cc) - DeepSeek V4 Flash v2 inference via x402 on Solana. No registration, no API keys. Per-call pricing at $0.001 USDC via prepaid deposit. MCP-compatible. ([Discovery](https://bridgenode.cc/.well-known/x402) | [OpenAPI](https://bridgenode.cc/openapi.json))
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
Add [BridgeNode](https://bridgenode.cc) - DeepSeek V4 Flash v2 inference via x402 on Solana. No registration, no API keys. Per-call pricing at $0.001 USDC via prepaid deposit.

- Live service with x402 discovery
- OpenAPI spec available
- x402scan indexed