### PR TITLE
Obolpay x402 Gateway to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,3 +1291,4 @@ A composable trio of x402-payable APIs designed to be chained by autonomous agen
 - ✅ **[VeraData](https://api.veradata.dev)** — Verified LATAM data & sanctions/compliance screening. Call to verify any counterparty before onboarding or transacting. `$0.02–$0.10`/call.
 
 **Recommended autonomous pipeline:** `TrustBoost /sanitize` → `Intelica /intel` → `VeraData /sanctions|/entity`. All three share the same account-free, subscription-free, wallet-only x402 model on Base + Solana.
+- [Obolpay x402 Gateway](https://x402.obolpay.xyz/) - Pay-per-call premium data on Base (USDC). Free preview embedded in the 402 challenge (evaluate before paying) + self-served reference client at /client.py. Machine-readable discovery at /.well-known/x402.


### PR DESCRIPTION
Live x402 pay-per-call data gateway on Base (USDC), own domain. Adds a free preview in the 402 challenge (evaluate before paying) and a self-served reference client at /client.py. Discovery: /.well-known/x402, /llms.txt.