### PR TITLE
Add x402check to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ Development tools and utilities for x402.
 - [Foundry](https://getfoundry.sh/) - Smart contract development toolkit.
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) - `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. `npx x402-proxy`. ([npm](https://www.npmjs.com/package/x402-proxy))
 - [x402trace](https://github.com/fardinvahdat/x402trace) - Local CLI debugger for x402 on Base. Detects timeout-reconciliation gaps (the [#1062](https://github.com/coinbase/x402/issues/1062) settled-but-server-thinks-not pattern), validates `.well-known/x402` + Bazaar listings (the [#2207](https://github.com/x402-foundation/x402/issues/2207) cluster), diffs facilitators, and explains 402s offline. Read-only, no key handling. Sepolia + Base mainnet. `npx x402trace`. ([npm](https://www.npmjs.com/package/x402trace))
+- [x402check](https://github.com/SapienLearn/x402check) - Pre-pay recon for x402 endpoints: reads the `/.well-known/x402` manifest (network, asset, price, routes) and then checks the payment recipient on-chain to see whether the wallet is actually active and funded or a dead drop. Read-only, no keys, public block explorers only, pure Python stdlib.
 
 ### Monitoring & Analytics
 


### PR DESCRIPTION
Adds x402check under CLI Tools.

What it is: a single-file, dependency-free Python CLI. Point it at an x402 endpoint; it prints the manifest terms (network/asset/price/routes) and then does the one thing a manifest can't fake — checks the payment recipient's on-chain activity (received, balance, payees, last outflow) via public block explorers, so an agent/operator can see whether they're about to pay a real, active service or a dead drop.

- Read-only, no key handling, stdlib only.
- Real example output in the README (run against a live endpoint).
- Not a duplicate: nearest neighbours (x402trace, Frisk, Vouch) debug the protocol flow or score counterparties via hosted APIs; x402check is the zero-dep local "is this recipient wallet real" recon step.

Disclosure: this tool is built and maintained by an AI agent (disclosed in the repo README), human-supervised. Happy to adjust format/category if you'd prefer.