### PR TITLE
Add Denpyo — Japan Invoice & Receipt Reader (production x402 service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Real companies using x402 in production with proven scale and transaction volume
 - [ToolSnap MCP](https://mcp.toolsnap.app) — 28 context-efficient MCP tools for AI agents: web extraction, data processing, SEO, image processing. Flagship `fetch_extract` benchmarked at 98.1% token reduction (53,820 → 2,001 tokens, saving ~$0.156/call at Sonnet pricing). x402 v2 on Base with EIP-3009 `transferWithAuthorization`. Dual payment: pay-per-call $0.02 USDC or prepaid ($0.50 deposit → $0.01/call off-chain, no per-call gas, no 402 round-trip). 27 tools free, no API keys. Cloudflare Workers edge-native, 0ms cold start. Glama A rated. ([GitHub](https://github.com/icosaedro-git/toolsnap-mcp) | [Glama](https://glama.ai/mcp/connectors/app.toolsnap/toolsnap-mcp))
 
 - [Veles Finance Agent](https://veles-finance-gateway.fly.dev) - Production FastAPI + LangGraph financial analysis service with x402 paywall on Base. Provides SEC 10-K extraction, stock due diligence, and Kelly Criterion at $0.01-$0.05 USDC per request. ([Discovery](https://veles-finance-gateway.fly.dev/.well-known/x402))
+
+- [Denpyo — Japan Invoice & Receipt Reader](https://denpyo-api.hp-vladic.workers.dev) - OCR Japanese invoices (請求書) and receipts (領収書) into structured JSON — vendor, line items, 8%/10% consumption-tax breakdown — with the qualified-invoice registration number (T+13 digits) verified against Japan's National Tax Agency registry in the same call. $0.01-$0.04 USDC on Base & Solana. Failed analyses are not charged. MCP: `npx -y denpyo-mcp`. ([OpenAPI](https://denpyo-api.hp-vladic.workers.dev/openapi.json) | [llms.txt](https://denpyo-api.hp-vladic.workers.dev/llms.txt) | [GitHub](https://github.com/vladic-corp/denpyo-api))
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
## What

Adds **Denpyo — Japan Invoice & Receipt Reader** to Production Implementations.

- Live production service: https://denpyo-api.hp-vladic.workers.dev
- OCR Japanese invoices (請求書) and receipts (領収書) into normalized JSON (vendor, line items, 8%/10% consumption-tax breakdown), with the qualified-invoice registration number (インボイス登録番号, T+13 digits) extracted **and verified against the National Tax Agency registry** in the same paid call — the only OCR × registry-verification combo for Japanese documents on x402.
- x402 v2, USDC on Base + Solana, CDP facilitator. Registered on x402scan (4/4 resources validated). Failed analyses return 4xx and are not charged.
- MCP server: `npx -y denpyo-mcp` (accepts local file paths or URLs).
- Sister service of Kaisha (PR #913).

One project = one PR, per contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)