### PR TITLE
Add BountyVerdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,6 +1018,7 @@ Projects building with or extending x402.
 - [x402 Surface Check](https://github.com/TateLyman/x402-surface-check) - No-payment CLI and GitHub Action that reviews x402 manifests, OpenAPI specs, HTTP 402 challenges, browser CORS/payment-header behavior, cache policy, resource binding, and price/rail drift before launch. ([npm](https://www.npmjs.com/package/x402-surface-check)) ([Action](https://github.com/marketplace/actions/x402-surface-check))
 - [x402 Triage MCP](https://github.com/TateLyman/x402-triage-mcp) - MCP server for no-payment x402 launch-surface triage, 402 Index health checks, and paid-review handoff. Tools: `triage_x402_surface`, `watch_402_index`, and `x402_paid_paths`. ([npm](https://www.npmjs.com/package/x402-triage-mcp)) ([MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.TateLyman%2Fx402-triage-mcp))
 - [AI Code Review API](https://x402-code-review.x402-cr.workers.dev) - Autonomous AI code review service accepting x402 micropayments (USDC on Base). Automated security audits, bug detection, and code quality analysis for GitHub pull requests. ([Docs](https://x402-code-review.x402-cr.workers.dev/.well-known/x402.json))
+- [BountyVerdict](https://github.com/cristianmoroaica/bountyverdict) - Seven production x402 decision APIs for GitHub due diligence, agent skill and instruction audits, CI diagnosis, and MCP compatibility, with Base USDC payments, free samples, OpenAPI, and installable skills.
 
 ## 📊 Ecosystem Market Data
 


### PR DESCRIPTION
## Add BountyVerdict

**What:** Adds BountyVerdict to Ecosystem Projects → Developer Tools.

**Why:** It provides seven documented production x402 decision APIs for coding agents, with free samples, OpenAPI, and installable agent skills.

**Quality checklist:**
- [x] Actively maintained
- [x] Well documented
- [x] Directly related to x402
- [x] Link is working
- [x] Uses the required format

**Category:** Ecosystem Projects → Developer Tools