### PR TITLE
Add AgentLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Client libraries for making x402 payments.
 - [Agent Wallet SDK](https://www.npmjs.com/package/agentwallet-sdk) - Non-custodial smart contract wallets for AI agents with on-chain spend limits and operator model. Base L2. ([npm](https://www.npmjs.com/package/agentwallet-sdk))
 - [viem](https://viem.sh/) - TypeScript library used for signing payments.
 - [ethers.js](https://docs.ethers.org/) - Alternative Ethereum library.
-- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Beta local-first wallet runtime for AI agents with x402 payments and DeFi operations. It discovers x402 services, previews payment terms, and executes approved Solana x402 API payments; EVM x402 is prepare-only.
+- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Open-source, local-first wallet for AI agents, with x402 payments and DeFi tools for Base, Solana, and Ethereum, including swaps, lending, and borrowing. Keys are stored in the macOS Keychain.
 
 ### Rust
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Client libraries for making x402 payments.
 - [Agent Wallet SDK](https://www.npmjs.com/package/agentwallet-sdk) - Non-custodial smart contract wallets for AI agents with on-chain spend limits and operator model. Base L2. ([npm](https://www.npmjs.com/package/agentwallet-sdk))
 - [viem](https://viem.sh/) - TypeScript library used for signing payments.
 - [ethers.js](https://docs.ethers.org/) - Alternative Ethereum library.
+- [AgentLayer](https://github.com/lopushok9/Agent-Layer) - Beta local-first wallet runtime for AI agents with x402 payments and DeFi operations. It discovers x402 services, previews payment terms, and executes approved Solana x402 API payments; EVM x402 is prepare-only.
 
 ### Rust
 


### PR DESCRIPTION
## Add AgentLayer

**What:** Adds AgentLayer, an open-source, local-first wallet for AI agents, with x402 payments and DeFi tools for Base, Solana, and Ethereum, including swaps, lending, and borrowing. Keys are stored in the macOS Keychain.

**Why:** It gives x402 users a buyer-side wallet flow backed by local key storage.

**Quality Checklist:**
- [x] Resource is actively maintained.
- [x] README documents installation and supported wallet flows.
- [x] Directly related to the x402 protocol.
- [x] Canonical GitHub link is public and working.
- [x] Entry follows the required format.

**Category:** Wallet Integration