### PR TITLE
Add Agent Commerce Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ x402 v2. MCP server on npm. Dataset actively growing.
 - [Paybound](https://github.com/pando-b/paybound) - Open-source spending controls for AI agents making x402 payments. Per-agent budgets, time-windowed limits, circuit breakers, and full audit trail. Drop-in `@x402/fetch` replacement. MIT licensed.
 - [PolicyLayer](https://policylayer.com) - Non-custodial spending controls for AI agents with crypto wallets. Enforces daily spending limits, per-transaction caps, recipient whitelists, and rate limiting without holding private keys.
 - [ICME Labs](https://docs.icme.io) - Formal verification for AI agent actions using the ARc paper approach. Natural language policies compile to SMT-LIB formal logic, checked by an SMT solver — SAT = allowed, UNSAT = blocked. Wrapped in zero knowledge proofs for sub-1s verification, private policies, and  cryptographic audit trails per decision. 99%+ soundness under adversarial pressure. $0.10 USDC per check on Base, no account needed. Live demo policy available. 
+- [Agent Commerce Guard](https://github.com/fxjim/agent-commerce-guard) - Local-first approval gates, preflight validation, and transaction receipts for AI agents using x402 and Base USDC; includes paid endpoint checks and an installable buyer skill.
 
 ## 🔗 Related Protocols
 


### PR DESCRIPTION
## Add Agent Commerce Guard

**What:** Adds Agent Commerce Guard to the Spending Controls & Policy Enforcement section.

**Why:** It gives x402 builders a local-first approval and receipt layer that preflights payment metadata, checks the exact Base USDC payment tuple, requires explicit approval, and verifies transaction hashes before unlock.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Spending Controls & Policy Enforcement

**Testing:** Verified the GitHub source and live product return HTTP 200, `/.well-known/x402` returns HTTP 200, the paid download correctly returns HTTP 402, and the project buyer preflight passes all six metadata and x402 checks.

**Disclosure:** I maintain Agent Commerce Guard.