### PR TITLE
Add PayAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Payment verification and settlement services.
 - [AlgoVoi](https://api1.ilovechicken.co.uk/.well-known/agent.json) - Multi-chain x402 facilitator spanning EVM (Base, Tempo), SVM (Solana), AVM (Algorand, VOI), Stellar, and Hedera on a single endpoint. Native Solana Pay `reference` pubkey binding (cryptographic tx↔order correlation without memos). Also implements MPP and AP2 at the same URL. [Open-source MCP adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters).
 - [x402-saas](https://x402-saas.surge.sh) - Hosted facilitator + zero-SDK onboarding proxy on Base. SIWE auth, slug-routed multi-tenant data plane, 1% of routed USDC volume. MIT-licensed self-host alternative at [x402-kit](https://github.com/kite-builds-erik/x402-kit). Live demo at [`/__x402/health`](https://x402-saas.onrender.com/__x402/health).
 - [Primer](https://x402.primer.systems) - Free x402 facilitator supporting Base and SKALE Base networks, with full ERC-20 support. v1 and v2 x402 both accepted. Batch settlement enabled. [Documentation](https://docs.primer.systems).
+- [PayAI](https://facilitator.payai.network) - Multi-chain hosted facilitator with USDC settlement across EVM networks (Base, Polygon, Avalanche, Arbitrum, Sei, X Layer, SKALE) and Solana mainnet. Publishes a discovery bazaar of paid endpoints and accepts both x402 and MPP payment challenges. ([Supported networks](https://facilitator.payai.network/supported)) ([Discovery](https://facilitator.payai.network/discovery/resources))
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
## Add PayAI

**What:** [PayAI](https://facilitator.payai.network), a multi-chain hosted x402 facilitator with USDC settlement across EVM networks (Base, Polygon, Avalanche, Arbitrum, Sei, X Layer, SKALE) and Solana mainnet. It publishes a discovery bazaar of paid endpoints and accepts both x402 and MPP payment challenges.

**Why:** The Facilitators section has no PayAI entry, even though PayAI already appears indirectly in the list (the Agent402 entry cites it as one of the three facilitators it settles across). It's one of the few facilitators offering native Solana settlement alongside broad EVM coverage on a single endpoint, which is useful for agent builders choosing a cross-chain facilitator.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Facilitators → Hosted Facilitators

**Testing:** Supported networks are live at https://facilitator.payai.network/supported and the discovery bazaar at https://facilitator.payai.network/discovery/resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
