### PR TITLE
Add x402 Finance API – Live crypto prices on Base Mainnet at $0.002 USDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,7 @@ Projects building with or extending x402.
 - [Forge Cascade](https://forgecascade.org/) - Experimental institutional memory and knowledge graph platform exposing x402 discovery metadata, payment OpenAPI docs, MCP, and A2A surfaces for Base USDC agent-commerce workflows. ([x402 discovery](https://forgecascade.org/.well-known/x402) | [Payment OpenAPI](https://forgecascade.org/openapi.payments.json) | [Agent card](https://forgecascade.org/.well-known/agent-card.json))
 - [Listing Roast x402](https://listing-roast-x402-service-production.up.railway.app) - Paid x402 API for builders launching agent-facing services: $0.001 listing scores, $0.01 full roasts, and a $0.01 Bazaar discovery audit for stale pricing, direct 402 metadata, and search visibility on Base USDC.
 - [Ren API](https://ren-api-production.up.railway.app) - Seed-oil-free restaurant intelligence for AI agents with restaurant lookup and dish-swap endpoints. Data sourced from live restaurant calls; $0.01 USDC per call on Base. ([Discovery](https://ren-api-production.up.railway.app/.well-known/x402.json) | [llms.txt](https://ren-api-production.up.railway.app/llms.txt))
+- [x402 Finance API](https://x402-paid-api.x402-finance.workers.dev) - Live cryptocurrency market data (BTC, ETH, SOL) protected by x402 V2. Real-time prices with 24h change. Exact **0.002 USDC** on Base Mainnet. Fully verified with Coinbase CDP Facilitator. Includes discovery manifest + LLM docs. [](https://x402-paid-api.x402-finance.workers.dev/api/paid-content)
 
 ### Charity & Social Impact
 


### PR DESCRIPTION
## Description
Adding a live x402 V2 market data endpoint optimized for high-frequency AI agent usage.

**Endpoint:** `https://x402-paid-api.x402-finance.workers.dev/api/paid-content`

### Key Details
- **Price:** 0.002 USDC (2000 atomic units)
- **Network:** Base Mainnet (`eip155:8453`)
- **Protocol:** Native x402 V2
- **Facilitator:** Coinbase CDP (verify + settle confirmed)
- **Data:** Live BTC, ETH, SOL prices + 24h change

### Discovery
- [x402.json](https://x402-paid-api.x402-finance.workers.dev/.well-known/x402.json)
- [llms.txt](https://x402-paid-api.x402-finance.workers.dev/llms.txt)

Successfully completed live settlements through the CDP Facilitator.