### PR TITLE
Update paysh-agent-recipes entry to reflect the full library

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Full working examples and templates.
 - [Fetch Client](https://github.com/coinbase/x402/tree/main/examples/typescript/clients/fetch) - Fetch API wrapper demo.
 - Python Requests - Python client example.
 - [agent-starter-x402](https://github.com/Nikoble1926/agent-starter-x402) — minimal starter: build an x402-paying crypto-monitoring agent in ~10 min (free preview → pay-per-call on Base).
-- [paysh-agent-recipes](https://github.com/nickisanders/paysh-agent-recipes) - Copy-pasteable recipes for AI agents that pay per request over pay.sh (Solana Foundation and Google Cloud), no API keys. Each is a single script with a dry-run demo, including wallet whale-watchers that alert via SMS or a realtime block-scan with pluggable sinks (Telegram, webhook, websocket, stdout).
+- [paysh-agent-recipes](https://github.com/nickisanders/paysh-agent-recipes) - A library of copy-pasteable AI agent recipes on pay.sh (Solana Foundation and Google Cloud), no API keys. Each is a single bash script with a zero-setup dry-run demo: onchain monitors, web and data pipelines, and a guardrails suite (spend caps, human approval, rate limits, spend reports) for agents that pay per request over x402.
 
 ## 🎨 Use Cases & Patterns
 


### PR DESCRIPTION
Small update to my existing entry under Client Examples.

When I first submitted (#714), paysh-agent-recipes was two whale-watcher recipes. It has since grown into a broader library, so the one-line description is out of date. This refreshes it to cover what is actually there now:

- onchain monitors
- web and data pipelines
- a guardrails suite (spend caps, human approval, rate limits, spend reports) for agents that pay per request

Same repo, same link, no new entry. Every recipe is still a single bash script with a zero-setup dry-run demo.