### PR TITLE
Add ManyHands Evidence API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,8 @@ Projects building with or extending x402.
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
 
+- [ManyHands Evidence API](https://manyhands.uk/evidence-api/) - Deterministic snapshots, change checks, deadline scans, citation packs, and PDF evidence for supported UK official sources, priced at $0.01-$0.09 USDC per call on Base via x402. ([Catalog](https://api.manyhands.uk/catalog) | [OpenAPI](https://api.manyhands.uk/openapi.json))
+
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.
 


### PR DESCRIPTION
## Summary

- add the ManyHands Evidence API to the Tools & Services section
- describe its deterministic UK official-source evidence products and x402 pricing
- link the public catalog and OpenAPI specification

## Validation

- documentation page returns HTTP 200
- catalog and OpenAPI endpoints return HTTP 200
- an unpaid request to the public API returns the expected HTTP 402 payment challenge
