### PR TITLE
Add TDnet Silent-Change Diff API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,3 +1539,5 @@ A composable trio of x402-payable APIs designed to be chained by autonomous agen
 
 **Recommended autonomous pipeline:** `TrustBoost /sanitize` → `Intelica /intel` → `VeraData /sanctions|/entity`. All three share the same account-free, subscription-free, wallet-only x402 model on Base + Solana.
 - [Obolpay x402 Gateway](https://x402.obolpay.xyz/) - Pay-per-call premium data on Base (USDC). Free preview embedded in the 402 challenge (evaluate before paying) + self-served reference client at /client.py. Machine-readable discovery at /.well-known/x402.
+
+- [TDnet Silent-Change Diff API](https://zmmhycpktdsynzorbujg.supabase.co/functions/v1/api) — Sentence-level diffs between consecutive Japanese TDnet (Tokyo Stock Exchange timely disclosure) filings of the same company and document type. Surfaces exactly what a 訂正 (correction) filing changed — whether numbers actually moved or only the wording was fixed. `$0.02`/call USDC on Base mainnet. Free `/api/recent` teaser, no signup, no API key. Filing text is Japanese; facts only, no investment advice.


### PR DESCRIPTION
Adds an x402-payable API that returns sentence-level diffs between
consecutive Japanese TDnet disclosures.

Japanese listed companies frequently re-file a disclosure as a 訂正
(correction). The question that matters is whether the numbers actually
changed or only the formatting was fixed — answering it currently means
opening and comparing two Japanese PDFs by hand. This API returns the
changed sentences as facts, largest change first, with links to both
original PDFs.

Live on Base mainnet, $0.02/call, no signup. Free /api/recent endpoint.
([Discovery](https://zmmhycpktdsynzorbujg.supabase.co/functions/v1/api/.well-known/x402) | [llms.txt](https://zmmhycpktdsynzorbujg.supabase.co/functions/v1/api/llms.txt) | [OpenAPI](https://zmmhycpktdsynzorbujg.supabase.co/functions/v1/api/openapi.json))

