### PR TITLE
Add Bounty Truth API

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Real companies using x402 in production with proven scale and transaction volume
 - [SuVerse Pay](https://suverse-pay.suverse.io) - Payment gateway + API catalog with ~490 paid endpoints on one origin: crypto market data, Polymarket smart-money verdicts, token-safety forensics (Base + Solana), macro/gov datasets, and an x402 endpoint liveness probe. $0.05–$0.75 USDC per call, multi-chain settlement (Base + Solana + Cosmos Noble) via a self-hosted facilitator, no API keys or signup. ([OpenAPI](https://proxy.suverse.io/openapi.json) | [Catalog](https://suverse-pay.suverse.io/catalog) | [MCP](https://www.npmjs.com/package/@suverselabs/mcp-server) | [Buyer SDK](https://www.npmjs.com/package/@suverselabs/x402-client))
 
 - [Studio X](https://www.studio-x.cc) - Production image and video generation API with 11 models, per-generation x402 pricing, and USDC settlement on Base. ([OpenAPI](https://www.studio-x.cc/openapi.json) | [x402 discovery](https://www.studio-x.cc/.well-known/x402))
+- [Bounty Truth API](https://github.com/Joe-Wang-hangzhou/bounty-truth-api) - Open-source x402 API that checks public GitHub issue bounties for closure, cancellation, linked pull requests, assignees, claimants, and repository staleness before coding work begins. Live on Base at $0.001 USDC per call with an OpenAPI 3.1 contract.
 
 ### Production Success Metrics
 


### PR DESCRIPTION
## Add Bounty Truth API

**What:** Adds Bounty Truth API, an open-source x402 service that evaluates whether a public GitHub issue bounty is still actionable using live issue, pull-request, claimant, assignee, and repository-staleness evidence.

**Why:** It gives autonomous coding agents a low-cost preflight check before they commit work to a bounty that may already be closed, cancelled, claimed, or stale.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Production Implementations

**Testing:** Verified the repository and OpenAPI links return HTTP 200, the unpaid production endpoint returns HTTP 402, and `git diff --check` passes.