### PR TITLE
Add ArisPay Facilitator to Hosted Facilitators

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Payment verification and settlement services.
 - [Primer](https://x402.primer.systems) - Free x402 facilitator supporting Base and SKALE Base networks, with full ERC-20 support. v1 and v2 x402 both accepted. Batch settlement enabled. [Documentation](https://docs.primer.systems).
 - [Solvador](https://solvador.com) - Multi-network, multi-scheme x402 facilitator: 10 EVM chains (Base, Arbitrum, Optimism, Polygon, Avalanche, Celo, Linea, Unichain, World Chain, Monad) plus Solana and NEAR mainnet. Supports `exact`, `upto` (Permit2), and `batch-settlement` schemes. Settled-transaction dashboard with API keys. [Supported networks & schemes](https://api.solvador.com/supported) · [Blog](https://blog.solvador.com)
 - [NEAR x402 Facilitator](https://x402.mikedotexe.com/) - Open-source, API-key-gated facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery.
+- [ArisPay Facilitator](https://facilitator.arispay.app) - Free, public x402 facilitator for Base mainnet with USDC and EURC settlement. Open /verify and /settle, no API key required. Discovery at [/facilitator](https://facilitator.arispay.app/facilitator) and [/supported](https://facilitator.arispay.app/supported).
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
Adds ArisPay Facilitator to Hosted Facilitators. One entry, factual copy only — everything stated is verifiable in-band: `GET /supported` (Base mainnet `eip155:8453`, USDC + EURC, EIP-3009, machine-readable no-fee policy), `GET /facilitator` (discovery), plus account-free observability at `/status`, `/metrics`, `/trust`, `/receipts/{txHash}`.
