### PR TITLE
Remove dead Discord invite, point Issues at the current protocol repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,8 +1032,7 @@ Connect with the x402 community.
 
 ### Official Channels
 
-- [x402 Foundation Discord](https://discord.gg/x402) - Official community server.
-- [GitHub Issues](https://github.com/coinbase/x402/issues) - Technical Q&A and bug reports.
+- [GitHub Issues](https://github.com/x402-foundation/x402/issues) - Technical Q&A and bug reports.
 - [Twitter @x402org](https://twitter.com/x402org) - Official updates and announcements.
 
 ### Developer Communities
@@ -1468,7 +1467,6 @@ Looking for more awesome lists?
   <a href="https://x402.org">Official x402 Website</a> •
   <a href="https://github.com/coinbase/x402">Protocol Repo</a> •
   <a href="https://docs.cdp.coinbase.com/x402">Documentation</a> •
-  <a href="https://discord.gg/x402">Discord</a> •
   <a href="https://twitter.com/x402org">Twitter</a>
 </p>
 


### PR DESCRIPTION
Two broken links under **Official Channels**, both verifiable.

### 1. `discord.gg/x402` no longer resolves

Listed twice — once under Official Channels as "Official community server", once in the footer.

```
$ curl -s https://discord.com/api/v10/invites/x402
{"message": "Unknown Invite", "code": 10006}
```

Removed rather than replaced: I could not verify a live official server to substitute. The only invite I found that resolves is a general agent/crypto community rather than an x402 one, so I did not want to put it under "Official".

For what it's worth, two nearby links are also worth a look, and I have left both alone since they are judgment calls rather than errors:

- `discord.gg/KEhdhn6v` (x402jobs, cited elsewhere online) is also dead.
- `t.me/x402builders` under **Developer Communities** is described as "Active developer chat" and currently shows **5 subscribers**.

### 2. GitHub Issues points at the smaller repo

`coinbase/x402` has 129 stars; `x402-foundation/x402` has 6,416 and is where the code and issue traffic live. Repointed.

---

Net: **+1 / −3**, README only. Happy to restore the Discord line if there is a current invite I missed — I would rather this list point somewhere real.