### PR TITLE
Add InsumerAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [InsumerAPI](https://insumermodel.com/ai-agent-verification-api/) - On-chain condition checks as x402 pay-per-call: signed boolean attestations (token balance, NFT ownership, EAS, agent standing via ERC-8004 and ERC-7710) across 38 chains. $0.05 per attest, USDC on Base via CDP facilitator, no API key. ECDSA-signed, JWKS-verifiable offline. ([Discovery](https://insumermodel.com/.well-known/x402) | [OpenAPI](https://api.insumermodel.com/openapi.json) | [llms.txt](https://insumermodel.com/llms.txt))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Adds InsumerAPI: signed on-chain condition checks for AI agents (token balances, NFT ownership, EAS attestations, and agent standing via ERC-8004 and ERC-7710) across 38 chains, payable per call over x402 in USDC on Base with no API key. Live discovery: https://insumermodel.com/.well-known/x402

🤖 Generated with [Claude Code](https://claude.com/claude-code)