### PR TITLE
Add ActionSeal Personalized Agent Commerce Launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ Projects building with or extending x402.
 
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
+- [ActionSeal Personalized Agent Commerce Launch](https://github.com/jaxassistant55/actionseal-personalized-agent-commerce-launch) - Turns public product facts into a buyer-specific 12-file launch and discovery package for 20 USDC on Base. Includes a free nonpaying preflight, an exact x402 V2 payment contract, and an Agent Skill for machine-readable evaluation.
 
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.


### PR DESCRIPTION
## Add ActionSeal Personalized Agent Commerce Launch

**What:** Adds one entry for ActionSeal Personalized Agent Commerce Launch to the `Tools & Services` section.

**Why:** The live x402 V2 service turns bounded public product facts into a buyer-specific 12-file launch and machine-discovery package. Its public repository also provides a free nonpaying preflight and Agent Skill so developers can inspect the exact contract before deciding whether to purchase.

**Impact:** x402 developers and agent operators gain a documented launch-packaging service with an exact Base USDC payment contract and a no-spend evaluation path. This entry makes no transaction-volume or adoption claim.

**Quality Checklist:**
- [x] Resource is actively maintained.
- [x] Well documented with clear usage instructions.
- [x] Directly related to the x402 protocol.
- [x] Public source and live service links are working.
- [x] Follows the required contribution format.
- [x] No existing README, pull request, or issue duplicate was found.

**Validation:**
- Public GitHub source returned HTTP 200.
- Live product page returned HTTP 200.
- Free sample and validator returned HTTP 200.
- Unpaid checkout returned HTTP 402 with x402 V2, Base mainnet, canonical USDC, and the documented 20 USDC amount.
- The source repository's offline suite passed 7/7 tests.
- `git diff --check` passed.

**Category:** Tools & Services
