### PR TITLE
Add Agent Page Publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,8 @@ Projects building with or extending x402.
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
 
+- [Agent Page Publish](https://token-safety-api-eta.vercel.app) - Instant static page hosting for AI agents: pay $0.02 USDC via x402, POST HTML (up to 500KB), get back a public URL immediately. No signup, no account. USDC on Solana mainnet. ([llms.txt](https://token-safety-api-eta.vercel.app/llms.txt))
+
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.
 


### PR DESCRIPTION
Adds a listing for an x402-payable static page publishing API: agents pay $0.02 USDC (Solana mainnet) and POST HTML to get back a public URL instantly.