### PR TITLE
Add Agent Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,8 @@ Projects building with or extending x402.
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
 
+- [Agent Translate](https://token-safety-api-eta.vercel.app) - DeepL-powered machine translation for AI agents via x402. $0.01 USDC per call, up to 5000 characters, automatic source-language detection. No signup, no account. USDC on Solana mainnet. ([llms.txt](https://token-safety-api-eta.vercel.app/llms.txt))
+
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.
 


### PR DESCRIPTION
Adds a listing for an x402-payable machine translation API (DeepL-backed): agents pay $0.01 USDC (Solana mainnet) per call, up to 5000 characters, with automatic source-language detection.