### PR TITLE
Add x402 Pulse — analytics dashboard for x402 sellers

### DIFF
--- a/x402-pulse.md
+++ b/x402-pulse.md
@@ -1,0 +1,9 @@
+## x402 Pulse
+
+Free analytics dashboard for x402 API sellers.
+
+- **Live:** https://pulse.projectveritos.com
+- **GitHub:** https://github.com/hebridean-tech/x402-pulse
+- **Category:** Ecosystem Tool
+
+Connect any Base wallet and see real-time USDC revenue, endpoint health monitoring, and competitor pricing across 180+ x402 services. No signup, no API key.


### PR DESCRIPTION
## x402 Pulse

Free analytics dashboard for x402 API sellers.

**Live:** https://pulse.projectveritos.com  
**GitHub:** https://github.com/hebridean-tech/x402-pulse

### What it does
- Connect any Base wallet → see real-time USDC revenue
- Per-endpoint revenue breakdown
- Competitor pricing across 180+ x402 services
- Category benchmarks (are you undercharging?)
- Endpoint health monitoring (402 status, response time)

### Why
477+ x402 sellers have zero analytics tooling. Everyone checks basescan manually. Pulse fixes that — free, no signup, connect wallet and see your stats.

### Category
Ecosystem Tool / Analytics

Would love to be listed under an Ecosystem Tools or Analytics section. Happy to adjust the entry format to match.