### PR TITLE
Add K-Data — Korean market data API (kimchi premium, news translation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [🎨 Use Cases & Patterns](#-use-cases--patterns)
 - [🤖 AI Agent Integration](#-ai-agent-integration)
 - [Octodamus](https://api.octodamus.com) — AI market-intelligence API for agents. 33 pay-per-call x402 endpoints on Base ($0.01–$0.02, USDC, no keys): cross-venue derivatives facts, prediction-market odds, congressional trades, macro reference numbers, and a tokenized-equity suite (24/7 fair value, on-chain basis, and Arcus perp facts for Robinhood Chain). Ed25519-signed responses, MCP server, all endpoints cataloged in the CDP x402 Bazaar. ([llms.txt](https://octodamus.com/llms.txt)) ([Discovery](https://api.octodamus.com/.well-known/x402.json)) ([MCP](https://smithery.ai/server/octodamusai/market-intelligence))
+- [K-Data] — Korean market data for agents. 9 pay-per-call x402 endpoints on Base ($0.005–$0.12, USDC, no keys): kimchi premium on a tradeable USDT basis (not just the untradeable official-FX figure), premium history/percentiles from a continuous archive, Korean news translated to English. ([llms.txt](https://k-data-x402-production.theblack1022.workers.dev/llms.txt)) ([Catalog](https://k-data-x402-production.theblack1022.workers.dev/api/catalog)) ([MCP](https://www.npmjs.com/package/k-data-mcp))
 - [🔨 Tools & Utilities](#-tools--utilities)
 - [🧪 Testing & Development](#-testing--development)
 - [📚 Tutorials & Learning Resources](#-tutorials--learning-resources)


### PR DESCRIPTION
Adds K-Data, an x402-metered API serving Korean market data to agents.

Live: https://k-data-x402-production.theblack1022.workers.dev
Catalog: /api/catalog · OpenAPI: /openapi.json · llms.txt: /llms.txt
Settlement verified on Base mainnet via the CDP facilitator.

Differentiator worth noting for the list: it reports the kimchi premium on both the
official USD/KRW basis (the quoted figure) and the Upbit KRW/USDT basis (the margin
actually realizable given Korean capital controls). The two frequently disagree in
sign, so agents acting on the official number alone reach the opposite conclusion.

An MCP server (`k-data-mcp`) is published alongside it, with a free `list_endpoints`
tool and a hard spend cap.