### PR TITLE
Add CryptoAPIs Facilitator to Hosted Facilitators

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Payment verification and settlement services.
 - [Primer](https://x402.primer.systems) - Free x402 facilitator supporting Base and SKALE Base networks, with full ERC-20 support. v1 and v2 x402 both accepted. Batch settlement enabled. [Documentation](https://docs.primer.systems).
 - [Solvador](https://solvador.com) - Multi-network, multi-scheme x402 facilitator: 10 EVM chains (Base, Arbitrum, Optimism, Polygon, Avalanche, Celo, Linea, Unichain, World Chain, Monad) plus Solana and NEAR mainnet. Supports `exact`, `upto` (Permit2), and `batch-settlement` schemes. Settled-transaction dashboard with API keys. [Supported networks & schemes](https://api.solvador.com/supported) · [Blog](https://blog.solvador.com)
 - [NEAR x402 Facilitator](https://x402.mikedotexe.com/) - Open-source, API-key-gated facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery.
+- [CryptoAPIs Facilitator](https://cryptoapis.io/products/x402) - Non-custodial x402 v2 facilitator on Base and Solana (mainnet + testnets) with the `exact` scheme and a `payment-identifier` extension for correlating settlements with merchant orders. Buyers sign locally; gas is sponsored by the facilitator. Backed by CryptoAPIs' multi-chain infrastructure (20+ chains, native AML screening) and EU-based. [Supported networks](https://ai.cryptoapis.io/x402/merchant/supported) | [Docs](https://developers.cryptoapis.io/v-2.2024-12-12-175/RESTapis/x402/x402-merchant-facilitator)
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
Adds the CryptoAPIs x402 facilitator to the **Hosted Facilitators** list.

### What it is

A non-custodial x402 **v2** facilitator on Base and Solana. Buyers sign locally — the facilitator never holds buyer keys — and gas is sponsored in-process. It ships a `payment-identifier` extension so a settlement can be correlated back to a merchant order without memos.

### Live and verifiable

`/supported` is public and anonymous — no key needed:

```bash
curl -s https://ai.cryptoapis.io/x402/merchant/supported
```

```json
{"kinds":[{"x402Version":2,"scheme":"exact","network":"eip155:8453"},
          {"x402Version":2,"scheme":"exact","network":"eip155:84532"},
          {"x402Version":2,"scheme":"exact","network":"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"},
          {"x402Version":2,"scheme":"exact","network":"solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"}],
 "extensions":["payment-identifier"]}
```

Base mainnet (8453) + Base Sepolia (84532) + Solana mainnet + devnet, `exact` scheme.

### Checklist

- [x] Searched first — no existing CryptoAPIs entry in the README
- [x] One change per PR — single line added to Hosted Facilitators
- [x] Follows the `- [Name](link) - Description.` format
- [x] All links tested (product page, `/supported`, docs — all 200)

### Links

- Product: https://cryptoapis.io/products/x402
- Supported networks: https://ai.cryptoapis.io/x402/merchant/supported
- Docs: https://developers.cryptoapis.io/v-2.2024-12-12-175/RESTapis/x402/x402-merchant-facilitator