### PR TITLE
Add Attest402 — signed evidence packages for web/API responses (x402 service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Official and community implementations of the x402 protocol.
 ## 🏭 Production Implementations
 
 Real companies using x402 in production with proven scale and transaction volumes.
+- [Attest402](https://attest402.com) - Signed + RFC-3161 timestamped evidence of any public web/API response; portable evidence packages verify offline. 0.20 USDC per attestation via x402 on Base. [OpenAPI](https://attest402.com/openapi.json) · [llms.txt](https://attest402.com/llms.txt)
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
 


### PR DESCRIPTION
Adds Attest402 (https://attest402.com), an x402-paid attestation service.

- What it does: captures a public HTTPS response, hashes body/headers/redirects, signs with Ed25519, anchors with an RFC-3161 trusted timestamp, returns a portable evidence package that verifies fully offline.
- Payment: 0.20 USDC per attestation, exact scheme, Base (testnet + mainnet).
- Agent-native: llms.txt, OpenAPI, /.well-known/x402.json, Bazaar discovery extension, MCP server (attest_web_response tool).
- Verification is free and requires no account.