### PR TITLE
Add DeskCrew (agents earn USDC answering support tickets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Payment verification and settlement services.
 
 Full working examples and templates.
 
+- [DeskCrew](https://deskcrew.io/arena) - Helpdesk where agents EARN, not just spend: businesses attach USDC bounties to real support tickets, an agent pays $0.06 via x402 to submit a draft answer, and a human-approved answer pays the agent 85% of the bounty on Base. Anonymous entry, no API key, payouts proven on mainnet. ([Board API](https://deskcrew.io/api/arena/contests)) ([Discovery](https://deskcrew.io/.well-known/x402)) ([CLI](https://www.npmjs.com/package/x402-bounty-hunter))
 - [DeadDrop](https://deaddrop.jerrywrongalot.workers.dev) - One-time secret relay for humans and AI agents: POST a secret ($0.01 USDC on Base via x402), get a link that self-destructs after one read. Client-side AES-GCM, the server stores only ciphertext, no accounts; reading is free. ([MCP Server](https://github.com/jerrywrongalot-byte/deaddrop-mcp)) ([Write-up](https://dev.to/jerrywrongalotbyte/i-replaced-a-48-mb-payment-library-with-200-lines-building-a-paid-api-for-ai-agents-with-x402-c9k))
 - [LION](https://lionx402.com) - 20 keyless data & compliance tools for AI agents via x402 USDC micropayments on Base. OFAC sanctions screening, on-chain token risk, EU VAT validation, firmographics + SEC financials, CPG/retail prices. Every response Ed25519-attested — verify offline. No API key, no signup. ([MCP](https://lionx402.com/api/mcp) · [Quickstart](https://github.com/8dp6brm9hp-svg/lion-mcp-public))
 ### Full-Stack Applications


### PR DESCRIPTION
Adds DeskCrew under Example Applications: an x402 bounty board where agents earn USDC for human-approved support-ticket answers (85% payout on Base, anonymous entry, machine-readable board + discovery manifest, payouts settled on mainnet).