### PR TITLE
Add monad-x402-gate (Python standalone server, native-MON self-verified gate for Monad)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,9 @@ Server-side integrations for accepting x402 payments.
 - [switchboard](https://github.com/kcolbchain/switchboard) - Python middleware + on-chain escrow for agent payments. FastAPI/Flask `X402Middleware` server-side, gas budget tracker, reorg-safe nonce manager, and Solidity `AgentEscrow` with timeout/refund. Protocol-agnostic substrate (x402 + escrow shipping; MPP/AP2 in flight).
 - [Routeweiler](https://github.com/nikoSchoinas/routeweiler-python-sdk) — Python micropayment client for autonomous agents that auto-handles HTTP 402 across x402, L402, MPP-Tempo, and Stripe SPT. Enforces policy & budget, and produces payment traces for auditing. ([PyPI](https://pypi.org/project/routeweiler/))
 
+**Standalone Servers**
+- [monad-x402-gate](https://github.com/ColinkaMir/monad-x402-gate) - Self-verified x402 gate for Monad in a single stdlib file (~200 lines, zero dependencies): the client pays native MON, the server verifies locally over RPC (no facilitator, no contracts), sqlite replay store, 15-minute validity window. Running in production behind nginx with `/.well-known/x402` discovery. MIT. ([Engineering note](https://prooflines.org/monad/x402-on-monad/) | [Live endpoint](https://prooflines.org/monad/x402/network-concentration-report))
+
 ### Rust
 
 **Axum**


### PR DESCRIPTION
One addition to Server Frameworks & Middleware -> Python, under a new **Standalone Servers** subhead (it is a complete server rather than a framework plugin; happy to move it wherever fits better).

- **What it is:** a minimal self-verified x402 gate for Monad: single stdlib-Python file (~200 lines, zero dependencies). The client pays native MON, the server verifies the payment locally over RPC (recipient, value, receipt status, freshness window) with a sqlite replay store. No facilitator, no contracts, no SDK.
- **Live:** running in production at https://prooflines.org/monad/x402/network-concentration-report (returns a well-formed 402 with payment instructions; `/.well-known/x402` discovery published). First real purchase transcript with the on-chain tx hash is in the README.
- **Relation to existing entries:** conceptually adjacent to PipRail's local-verification approach, but as a copy-paste single-file server for one chain rather than a multi-chain SDK; complements the USDC/facilitator entries by covering the native-coin corner.
- Link tested, MIT licensed, description follows the format guidelines.