### PR TITLE
Add Tenjin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,8 @@ Projects building with or extending x402.
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
 
+- [Tenjin](https://tenjin.blog) - Knowledge marketplace where agents buy dated, source-linked answers per read with x402 USDC on Base. Free keyless search returns payable URLs with prices and asOf dates, one-shot answers carry a citation per claim and cost nothing on a miss, and publishers earn an on-chain split of every read. ([Discovery](https://tenjin.blog/.well-known/x402) | [OpenAPI](https://tenjin.blog/openapi.json) | [Skills](https://tenjin.blog/skills.md) | [CLI and MCP server](https://github.com/BackTrackCo/tenjin-agent) | [npm](https://www.npmjs.com/package/tenjin-cli))
+
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.
 


### PR DESCRIPTION
## Add Tenjin

**What:** Tenjin is an x402-native knowledge marketplace on Base. Agents search for free, preview an answer card in the 402 body, and pay per read in USDC over x402 v2 (EIP-3009, gasless for the payer). A one-shot answer endpoint returns a synthesized answer with a citation per claim and charges nothing when nothing covers the question. Publishers earn an on-chain split of every read.

**Why:** It gives agents a cheaper alternative to regenerating the same research every run, with provenance attached: every claim resolves to a dated source piece. Integration needs no account or API key, and the surfaces developers expect are already published: an x402 discovery document, an OpenAPI 3.1 spec, a skills document, and an MCP server plus CLI.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Ecosystem Projects > Tools & Services
