### PR TITLE
Add Cog Depot to Agent-to-Agent (A2A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@ AI-powered research and translation services for the Asian market — no other x
   - Google A2A protocol with x402 payment integration
   - Multi-chain support (Base, SKALE, Arbitrum)
 - [Revettr](https://revettr.com) - Counterparty risk scoring API for x402 agentic commerce. Scores wallet addresses, domains, IPs, and companies 0-100 for agent-to-agent payment safety.
+- [Cog Depot](https://cogdepot.com) - A2A marketplace where buyer and seller agents discover listings, negotiate deals, and settle. Keyless calls return a 402 whose `accepts` offers USDC credit packs on Base ($0.50 / $5 / $50); a first payment from an unknown wallet creates the account and returns its API key in that same response, so an agent onboards without a signup form. Agent Card + JSON-RPC `message/send`. ([Discovery](https://api.cogdepot.com/.well-known/x402)) | ([Agent Card](https://api.cogdepot.com/.well-known/agent-card.json))
 
 
 ### Multi-Agent Orchestration


### PR DESCRIPTION
Adds one entry to `### Agent-to-Agent (A2A)`, appended at the end of the category per CONTRIBUTING ("Add new items at the end of their category", "One change per PR").

**Entry**

`- [Cog Depot](https://cogdepot.com) - A2A marketplace where buyer and seller agents discover listings, negotiate deals, and settle. Keyless calls return a 402 whose accepts offers USDC credit packs on Base ($0.50 / $5 / $50); a first payment from an unknown wallet creates the account and returns its API key in that same response, so an agent onboards without a signup form. Agent Card + JSON-RPC message/send. ([Discovery](https://api.cogdepot.com/.well-known/x402)) | ([Agent Card](https://api.cogdepot.com/.well-known/agent-card.json))`

**Why it is x402-specific, not general payments**

The x402 rail is live in production, not a roadmap item. Verifiable right now:

| Check | Result |
|---|---|
| `GET https://api.cogdepot.com/.well-known/x402` | `200`, `network: base`, asset USDC `0x8335...2913` |
| `GET https://api.cogdepot.com/v1/feed` with no key | `402` with a populated `accepts` array |
| Tiers advertised | 1,000 credits / $0.50, 10,000 / $5.00, 100,000 / $50.00 |

The detail that seemed worth writing down for other x402 developers is the onboarding path: because the 402 challenge is served to unauthenticated callers, a wallet with no account can pay the offer and receive its API key in that response. There is no signup form in the loop, which is the property most agent integrations actually want from x402.

**Checklist against CONTRIBUTING**

- Searched first: `cogdepot` appears 0 times in the current README.
- Format: `- [Resource Name](link) - Description.`
- One category only (A2A), one change, one PR.
- Links tested: storefront, discovery manifest and Agent Card all return `200`.
- Not general blockchain content: every claim above is an x402 surface.
