### PR TITLE
Add Agentable — agent-readiness auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ Projects building with or extending x402.
 
 
 - [Viridis Agent Fleet](https://mcp.viridisconservation.com/agents) - Five deterministic carbon and compliance tools payable per call with x402 USDC on Base, covering quantity takeoff, GHG inventory, CSRD/IFRS S2 disclosure, clean-energy tax credits, and regulatory scanning. Includes a [free dry-run quickstart](https://mcp.viridisconservation.com/quickstart) and [open-source five-route demo client](https://github.com/jdhart81/viridis-agent-fleet/blob/main/scripts/x402_demo_client.py).
+- [Agentable](https://seo4agent.com/audit/run) - Agent-readiness auditor for websites — checks if your site is discoverable and usable by AI agents (L0–L5 framework). $0.10 USDC per audit on Base mainnet. No API key required. ([OpenAPI](https://seo4agent.com/openapi.json) | [GitHub](https://github.com/varustamov/agentable-core))
 
 ### Data & Social APIs
 - [IPIntel.ai](https://ipintel.ai/x402-api) - Machine-payable IP threat intelligence lookup via x402 on Base. Pay $0.001 USDC per IP lookup, no account or API key required. Returns JSON risk scoring, ASN/ISP context, hosting/proxy/Tor indicators, bot signals, and infrastructure metadata. Endpoint: `https://api.ipintel.ai/x402/?ip={ip}`. OpenAPI: `https://api.ipintel.ai/openapi.json`.


### PR DESCRIPTION
Add Agentable (https://seo4agent.com) — agent-readiness auditor for websites.

Checks if a site is discoverable and usable by AI agents using the L0–L5 framework. $0.10 USDC per audit on Base mainnet via x402 protocol. No API key required.