### PR TITLE
Add DopamineDesk x402 Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [DopamineDesk x402 Marketplace](https://ai-data-marketplace-1042299154756.us-central1.run.app) - 74 pay-per-request APIs on Base USDC with live contract proofs, buyer preflight tools, market and vendor risk reports, OpenAPI discovery, and an open-source MCP adapter. ([Discovery](https://ai-data-marketplace-1042299154756.us-central1.run.app/.well-known/x402) | [OpenAPI](https://ai-data-marketplace-1042299154756.us-central1.run.app/openapi.json) | [MCP](https://github.com/jblaz6335/mcp-server-aidatamarketplace))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
## Add DopamineDesk x402 Marketplace

**What:** Adds a production Base USDC marketplace with 74 pay-per-request APIs, live contract proofs, OpenAPI discovery, buyer preflight tools, decision reports, and a public MCP adapter.

**Why:** It gives x402 developers a working catalog for testing paid API discovery, settlement, contract inspection, and MCP-based purchasing.

**Quality Checklist:**
- [x] Resource is actively maintained or historically significant
- [x] Well-documented with clear usage instructions
- [x] Directly related to x402 protocol
- [x] Link is working and accessible
- [x] Follows contribution format

**Category:** Production Implementations
