### PR TITLE
Fix Aeon link to canonical repo (aeonfun/aeon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ x402-native GPU inference APIs that let agents pay autonomously for compute.
 - [Phidata Agents](https://github.com/phidatahq/phidata) - Multi-modal agents with x402.
 - [Vault-0](https://github.com/0-Vault/Vault-0) - Encrypted secret vault, agent monitor, and x402 wallet for OpenClaw. Handles 402 detection, EIP-3009 signing, and policy-gated auto-settlement.
 - [CardZero](https://cardzero.ai) - Payment wallet for AI agents on Base L2. Each agent gets an ERC-4337 smart contract wallet with owner-controlled spending rules (per-tx limits, daily caps, whitelist, freeze). x402 buyer support via `POST /v1/x402/pay`. [ClawHub](https://clawhub.ai/mrocker/cardzero) | [GitHub](https://github.com/mrocker/CardZero) | [API Docs](https://cardzero.ai/docs/api)
-- [Aeon](https://github.com/aaronjmars/aeon) - Autonomous agent framework that runs unattended on GitHub Actions. Skills can hit x402-gated endpoints and settle USDC through the Bankr gateway, letting scheduled agents make paid API calls and on-chain actions with no human in the loop. MIT. ([GitHub](https://github.com/aaronjmars/aeon))
+- [Aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework that runs unattended on GitHub Actions. Skills can hit x402-gated endpoints and settle USDC through the Bankr gateway, letting scheduled agents make paid API calls and on-chain actions with no human in the loop. MIT. ([GitHub](https://github.com/aeonfun/aeon))
 
 ### Asia Intelligence & Bilingual AI
 


### PR DESCRIPTION
The existing Aeon entry links to `github.com/aaronjmars/aeon`, which is now a redirect. The canonical repository moved to **[aeonfun/aeon](https://github.com/aeonfun/aeon)** (owner: Aeon Inc). This one-line change updates both links on the Aeon row to the canonical URL. No other changes.