### PR TITLE
Add Solana Pulse XaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [💡 Example Applications](#-example-applications)
 - [🎨 Use Cases & Patterns](#-use-cases--patterns)
 - [🤖 AI Agent Integration](#-ai-agent-integration)
+- [Solana Pulse XaaS](https://lobby-laptop-shame-achieved.trycloudflare.com/) — Solana data and agent tools over HTTP 402. Free `/sample`. Paid Jupiter quote ($0.01), web search ($0.01), HTTPS extract ($0.02), license heuristic ($0.10), install preflight ($0.15) in Solana USDC via PayAI. Official MCP registry: `io.github.TommoHCIO/solana-pulse-xaas`. ([llms.txt](https://lobby-laptop-shame-achieved.trycloudflare.com/llms.txt)) ([Discovery](https://lobby-laptop-shame-achieved.trycloudflare.com/.well-known/x402.json)) ([MCP](https://lobby-laptop-shame-achieved.trycloudflare.com/mcp))
 - [Octodamus](https://api.octodamus.com) — AI market-intelligence API for agents. 33 pay-per-call x402 endpoints on Base ($0.01–$0.02, USDC, no keys): cross-venue derivatives facts, prediction-market odds, congressional trades, macro reference numbers, and a tokenized-equity suite (24/7 fair value, on-chain basis, and Arcus perp facts for Robinhood Chain). Ed25519-signed responses, MCP server, all endpoints cataloged in the CDP x402 Bazaar. ([llms.txt](https://octodamus.com/llms.txt)) ([Discovery](https://api.octodamus.com/.well-known/x402.json)) ([MCP](https://smithery.ai/server/octodamusai/market-intelligence))
 - [🔨 Tools & Utilities](#-tools--utilities)
 - [🧪 Testing & Development](#-testing--development)


### PR DESCRIPTION
Adds a live Solana x402 + MCP seller.

Free sample: https://lobby-laptop-shame-achieved.trycloudflare.com/sample
MCP: https://lobby-laptop-shame-achieved.trycloudflare.com/mcp
Discovery: https://lobby-laptop-shame-achieved.trycloudflare.com/.well-known/x402.json
Official MCP registry: io.github.TommoHCIO/solana-pulse-xaas

Paid routes on Solana USDC via PayAI: quote 0.01, search 0.01, extract 0.02, license 0.10, preflight 0.15.