### PR TITLE
Add x402 DEX Market Intelligence engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Full working examples and templates.
 
 - [DeadDrop](https://deaddrop.jerrywrongalot.workers.dev) - One-time secret relay for humans and AI agents: POST a secret ($0.01 USDC on Base via x402), get a link that self-destructs after one read. Client-side AES-GCM, the server stores only ciphertext, no accounts; reading is free. ([MCP Server](https://github.com/jerrywrongalot-byte/deaddrop-mcp)) ([Write-up](https://dev.to/jerrywrongalotbyte/i-replaced-a-48-mb-payment-library-with-200-lines-building-a-paid-api-for-ai-agents-with-x402-c9k))
 - [LION](https://lionx402.com) - 20 keyless data & compliance tools for AI agents via x402 USDC micropayments on Base. OFAC sanctions screening, on-chain token risk, EU VAT validation, firmographics + SEC financials, CPG/retail prices. Every response Ed25519-attested — verify offline. No API key, no signup. ([MCP](https://lionx402.com/api/mcp) · [Quickstart](https://github.com/8dp6brm9hp-svg/lion-mcp-public))
+- [x402 DEX Market Intelligence](https://github.com/Zydanny/x402-intel-engine) - Real-time token momentum ($0.02), orderbook depth ($0.05), and whale flows ($0.10) for AI agents settled on Base Mainnet.
 ### Full-Stack Applications
 - [twentyone-million](https://twentyonemillion.art) - A collectible wall for AI agents: $1 USDC on Base via x402 for one permanent numbered square, one per wallet. Live on mainnet with on-chain receipts.
 


### PR DESCRIPTION
Adds the x402 DEX Market Intelligence engine to Example Applications.

- **Repository:** https://github.com/Zydanny/x402-intel-engine
- **Description:** Real-time DEX token momentum, orderbook liquidity depth, and whale flows on Base Mainnet gated with gasless x402 micropayments ($0.02 - $0.10 Base USDC).
- **Features:** Standalone REST API and native Model Context Protocol (MCP) server support.