### PR TITLE
Add FractalAI — post-quantum (ML-DSA-65/FIPS-204) proof API to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Official and community implementations of the x402 protocol.
 
 ## 🏭 Production Implementations
 
+- [FractalAI — Post-Quantum Proof API](https://fractalai.net.co) - 7 pay-per-call proof services signed with **post-quantum ML-DSA-65 / Dilithium-3 (NIST FIPS-204)**: digital signature, AI-decision notary, dataset & training provenance (C2PA), Know-Your-Agent identity, and CBOM sealing. USDC micropayments on Base (gasless EIP-3009, x402 **v2**); every proof is **offline-verifiable** (`signed_message` + `ml_dsa65.verify`). Machine-readable catalog at `/.well-known/x402.json`. To our knowledge, the first/only post-quantum proof API on x402.
 Real companies using x402 in production with proven scale and transaction volumes.
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
### What
Adds **FractalAI — Post-Quantum Proof API** to the Production Implementations list.

### Why it's a fit
FractalAI is a live x402 **v2** provider on Base offering 7 pay-per-call services whose receipts are signed with **post-quantum ML-DSA-65 / Dilithium-3 (NIST FIPS-204)** and are **verifiable offline** (each response echoes the exact `signed_message`, verified with `ml_dsa65.verify`). To our knowledge it's the first/only post-quantum proof API on x402.

### Services (USDC on Base, gasless EIP-3009)
| Endpoint | Price | Proves |
|---|---|---|
| `/api/x402/verify-proof` | $0.01 | verifies a PQC signature, returns a signed verdict |
| `/api/x402/sign` | $0.02 | ML-DSA-65 signature over your message/hash |
| `/api/x402/verify-agent` | $0.03 | Know-Your-Agent identity/credential check |
| `/api/x402/attest-decision` | $0.05 | notarizes an AI decision (input/output hashed, on-chain anchor) |
| `/api/x402/seal` | $0.05 | timestamped provenance seal (C2PA/drand) |
| `/api/x402/seal-cbom` | $0.05 | CBOM (ECMA-424) crypto-inventory seal |
| `/api/x402/attest-training` | $0.05 | training/dataset provenance (C2PA) |

### Discovery
- Machine-readable catalog: https://fractalai.net.co/.well-known/x402.json (x402 v2)
- OpenAPI: https://fractalai.net.co/openapi.json (registered on x402scan)
- MCP bridge: `npm i -g @fractalai/agent-passport-mcp`

All endpoints return a canonical x402 v2 PaymentRequired; served proofs verify offline. Homepage: https://fractalai.net.co