### PR TITLE
Add CortexCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
-
+- [CortexCloud](https://api.cortexcloud.org) - OpenAI-compatible AI gateway with x402 pay-per-call USDC micropayments on Base: classical, hybrid, and real-QPU quantum solvers for QUBO/Ising optimization problems (portfolio, TSP, scheduling, MAX-CUT) at $0.05-$1.50+ per call, plus a hosted 22-tool MCP server (Streamable HTTP). No API keys, no signup. ([OpenAPI](https://api.cortexcloud.org/openapi.json) | [llms.txt](https://api.cortexcloud.org/llms.txt) | [Discovery](https://api.cortexcloud.org/.well-known/x402))
 
 ### High-Volume Production Deployments
 


### PR DESCRIPTION
Add [CortexCloud](https://api.cortexcloud.org) to Production Implementations.

CortexCloud is a production OpenAI-compatible AI gateway with x402 pay-per-call USDC micropayments on Base (22 settled payments, live 402 challenges). It exposes classical, hybrid, and real-QPU quantum solvers for QUBO/Ising optimization at $0.05-$1.50+ per call, plus a hosted 22-tool MCP server (Streamable HTTP, URL-based - no install). No API keys, no signup.

Verified live discovery endpoints: [OpenAPI](https://api.cortexcloud.org/openapi.json), [llms.txt](https://api.cortexcloud.org/llms.txt), [.well-known/x402](https://api.cortexcloud.org/.well-known/x402), [agentsearch.txt](https://api.cortexcloud.org/.well-known/agentsearch.txt), [bazaar](https://api.cortexcloud.org/.well-known/bazaar).