### PR TITLE
Add LedgerProof Settlement Army to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ Major tech companies leveraging x402 in production include **Coinbase** (Native 
 - [b0xM4](https://b0xm4-solana-pulse.mulberry-boar.workers.dev) - **Meridian-powered Solana DLMM screener.** Real-time TVL, volume, organic score, smart wallet tracking, token safety, fee/TVL yield ranking. 5 endpoints, $0.0001–0.0005 USDC/call. Payout 7P7w3M9yQs5P... on Solana.
 - [agentfeeds.jp](https://api.agentfeeds.jp) - Japan regulatory, sanctions & DEX market data for AI agents. 27 paid endpoints ($0.001-$0.05) covering FSA/e-Gov regulatory events, MOF/OFAC sanctions screening, and Base DEX spread/peg statistics. REST + MCP.
 
+- [LedgerProof Settlement Army](https://ledgerproofhq.io) - 21 proof-gated data endpoints for agents, pay-per-call in USDC on Base via x402 ($0.001-$0.05, no account, no subscription): live web search and page extraction, prediction-market odds priced across **both** Polymarket and Kalshi with the cross-venue spread computed, FX and technical indicators, SEC filings, FDA recalls, CVE lookups, sanctions screening, DNS/RDAP, GLEIF LEI, Wikidata, Federal Register, World Bank indicators, and hash anchoring/verification. Settlement is proof-gated: every endpoint publishes an acceptance rule that can genuinely fail, and a deliverable that fails its own test is never charged for. Every settled call includes a free cryptographically anchored hash receipt with a verify_url that checks independently. ([Discovery](https://jmspfggpztykyubyzvlx.supabase.co/functions/v1/laen-army-discovery)) ([MCP](https://ledgerproofhq.io/api/laen/mcp)) ([Verifier](https://verify.ledgerproofhq.io))
+
 ## 🛠️ SDKs & Client Libraries
 
 Client libraries for making x402 payments.


### PR DESCRIPTION
Adds LedgerProof Settlement Army: 21 proof-gated x402 endpoints on Base mainnet (USDC), $0.001–$0.05 per call, no account or subscription.

**What makes it different from a plain paid API:** settlement is proof-gated. Every endpoint publishes an acceptance rule that can genuinely fail, and a deliverable that fails its own test is never charged for. Every settled call also returns a free cryptographically anchored hash receipt with a `verify_url` a buyer can check without trusting us.

One endpoint worth calling out: the prediction-market service returns the same outcome priced on **both** Polymarket and Kalshi with the cross-venue spread computed, rather than a per-venue market list.

- Discovery (all 21 with prices + acceptance rules): https://jmspfggpztykyubyzvlx.supabase.co/functions/v1/laen-army-discovery
- MCP server: https://ledgerproofhq.io/api/laen/mcp
- Open verifier (no account): https://verify.ledgerproofhq.io
- Registered on x402scan: https://laen-army-cdp.fly.dev/openapi.json

Checklist:
- [x] Searched first — not already listed
- [x] One change per PR (single line added)
- [x] Follows the `[Resource Name](link) - Description.` format
- [x] Links tested live