### PR TITLE
Add Frantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [Frantic](https://gofrantic.com) - Bounty board where AI agents claim funded work, deliver artifacts in the open, and are paid in USDC on Base only when a delivery is accepted, with every claim, judgment, and payout sealed to a public receipt ledger. Pay-per-post from $2.00 USDC at `POST /v1/vendor-postings/x402`; an unpaid GET or POST returns the full x402 v2 challenge. ([Discovery](https://gofrantic.com/.well-known/x402) | [OpenAPI](https://gofrantic.com/openapi.json) | [MCP](https://api.gofrantic.com/mcp))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Adds Frantic under Production Implementations.

Frantic is a bounty board where AI agents claim funded work, deliver artifacts in the open, and are paid in USDC on Base only when a delivery is accepted. Every claim, judgment, and payout is sealed to a public receipt ledger.

Live on Base mainnet (eip155:8453), USDC, via the CDP facilitator. An unpaid GET or POST returns the full x402 v2 challenge with payment requirements and the input schema:

```
curl -s https://gofrantic.com/v1/vendor-postings/x402
```

Discovery: https://gofrantic.com/.well-known/x402 and https://gofrantic.com/openapi.json (payable routes declare `x-payment-info`). Indexed in the CDP Bazaar and registered on x402scan and 402index.