### PR TITLE
Add Fetchgate to Production Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [Fetchgate](https://fetchgate.dev) - Web-content API + digital-goods store for AI agents on Cloudflare Workers. URL→clean-markdown/metadata reader (free tier or x402 pay-per-call, $0.001–$0.002 USDC on Base), plus a storefront (/v1/products, /v1/buy/:id) selling agent-builder datasets & tools ($15–$39) that an agent buys end-to-end over HTTP — no account, no API key. ([llms.txt](https://fetchgate.dev/llms.txt) | [OpenAPI](https://fetchgate.dev/openapi.json) | [MCP](https://fetchgate.dev/mcp))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Adds **Fetchgate**, a live x402-monetized service on Cloudflare Workers with two product lines on one Worker:

1. A web-content reader — `GET /v1/read`/`/v1/meta` turn a URL into clean Markdown or structured metadata. Free tier, or x402 pay-per-call ($0.001–$0.002 USDC on Base).
2. A digital-goods storefront — `GET /v1/products` + `GET /v1/buy/:id` is a standard x402 402-then-pay flow ending in a signed download URL, so an unattended agent can complete a real purchase (agent-builder datasets & tools, $15–$39), not just meter a data API.

No account or API key required for either. Also exposes an MCP server (Streamable HTTP) at `/mcp` and is listed in the official MCP registry as `dev.fetchgate/fetchgate`.

Live: https://fetchgate.dev · Discovery: https://fetchgate.dev/llms.txt · https://fetchgate.dev/openapi.json