### PR TITLE
Add outbid (default next URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,8 @@ Enable AI agents to make autonomous payments.
 
 - [AIIM — AI Instant Messenger](https://aiim.broke2builtai.com) - A persistent AIM-style world where AI agents keep an identity, chat in rooms, outsource work on a labor Exchange, and build compounding reputation — humans can only spectate (faithful Win98 UI with a live game-engine world). x402 premium lanes in USDC on Base with direct on-chain settlement (pay → resend with `X-PAYMENT: <tx_hash>`, replay-proof, no custodian): sponsor a chat room $1/day, priority registration $0.25, wallet-to-wallet agent tips ≥$0.01 with receipts posted in chat. One agent key also verifies on 27 free data skills and pay-per-call GLM inference. ([Agent Handbook](https://aiim.broke2builtai.com/skill.md)) ([x402 discovery](https://aiim.broke2builtai.com/.well-known/x402)) ([MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=aiim)) ([GitHub](https://github.com/lordbasilaiassistant-sudo/AIIM))
 
+- [outbid](https://outbid.sh) — Fallback next URL for agents. GET /top then GET /route. #1 is whoever paid USDC last. Skill: `npx skills add agent-default/outbid`.
+
 ### Agent Verification & Security
 
 - [Faro](https://farofinance.app) - Advisory verify-before-pay: check resource URLs and `payTo` addresses before the first x402 retry. Structured allow/warn/block verdicts via REST + MCP — fills the gap between facilitator settlement safety and counterparty legitimacy.

--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Enable AI agents to make autonomous payments.
 
 - [AIIM — AI Instant Messenger](https://aiim.broke2builtai.com) - A persistent AIM-style world where AI agents keep an identity, chat in rooms, outsource work on a labor Exchange, and build compounding reputation — humans can only spectate (faithful Win98 UI with a live game-engine world). x402 premium lanes in USDC on Base with direct on-chain settlement (pay → resend with `X-PAYMENT: <tx_hash>`, replay-proof, no custodian): sponsor a chat room $1/day, priority registration $0.25, wallet-to-wallet agent tips ≥$0.01 with receipts posted in chat. One agent key also verifies on 27 free data skills and pay-per-call GLM inference. ([Agent Handbook](https://aiim.broke2builtai.com/skill.md)) ([x402 discovery](https://aiim.broke2builtai.com/.well-known/x402)) ([MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=aiim)) ([GitHub](https://github.com/lordbasilaiassistant-sudo/AIIM))
 
-- [outbid](https://outbid.sh) — Fallback next URL for agents. GET /top then GET /route. #1 is whoever paid USDC last. Skill: `npx skills add agent-default/outbid`.
+- [outbid](https://outbid.sh) — Fallback next URL for agents. GET /top then GET /route. #1 is the highest settled bid. Skill: `npx skills add agent-default/outbid`.
 
 ### Agent Verification & Security
 


### PR DESCRIPTION
## What
Add [outbid](https://outbid.sh) under AI Agent Integration.

## Why
Exception handler for the next URL: GET /top then GET /route. #1 is whoever paid USDC last. Skill: `npx skills add agent-default/outbid`.

Not a marketplace / directory listing.

## Quality
- Live: https://outbid.sh
- Skill: https://github.com/agent-default/outbid
- Link verified 200