### PR TITLE
Add Agent Broker — live GLEIF/OFAC/sanctions MCP server (x402 billing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1539,3 +1539,4 @@ A composable trio of x402-payable APIs designed to be chained by autonomous agen
 
 **Recommended autonomous pipeline:** `TrustBoost /sanitize` → `Intelica /intel` → `VeraData /sanctions|/entity`. All three share the same account-free, subscription-free, wallet-only x402 model on Base + Solana.
 - [Obolpay x402 Gateway](https://x402.obolpay.xyz/) - Pay-per-call premium data on Base (USDC). Free preview embedded in the 402 challenge (evaluate before paying) + self-served reference client at /client.py. Machine-readable discovery at /.well-known/x402.
+

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Official and community implementations of the x402 protocol.
 ## 🏭 Production Implementations
 
 Real companies using x402 in production with proven scale and transaction volumes.
+- [Agent Broker](https://hatchloop.dev/agent-broker/) - Live GLEIF+SEC company verification, OFAC/EU/UN/UK+40 sanctions screening, and cross-border trade-restriction mapping as MCP calls. 11 read tools free (no key, no x402). Write tools (SMS, booking, voice calls to SMBs) use credits (Starter $9/1,000, Growth $29/3,500, Scale $99/13,000 at https://hatchloop.dev/pricing) or agents pay per-call via x402. MCP: `https://hatchloop.dev/mcp/agent-broker`. ([Skill/Install](https://github.com/basilalshukaili/agentbroker-skill) | [MCP](https://hatchloop.dev/mcp/agent-broker))
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
 


### PR DESCRIPTION
Agent Broker is a hosted MCP server (streamable-HTTP) providing live GLEIF LEI + SEC EDGAR company verification, OFAC/EU/UN/UK sanctions screening, and cross-border trade-restriction mapping. 11 read tools are free. Write tools (messaging, booking, voice) are billed via Polar at $9/90d — x402-compatible payment rail. Endpoint: https://hatchloop.dev/mcp/agent-broker — install guide: https://github.com/basilalshukaili/agentbroker-skill