### PR TITLE
Add Crawlier Studio x402 — pay-per-call image & voice AI on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [Crawlier Studio x402](https://48e0cb905290ad.lhr.life) - Pay-per-call image & voice AI generation on Base mainnet. image-01 / image-02 at 512/1024/2048 ($0.49–$1.79) and TTS ($0.05/1k chars). Backed by the same Crawlier Studio API that powers the public lhr.life endpoints; resells MiniMax inference at 90%+ margin. Free /trial endpoint, no signup, no API key. ([Discovery](https://48e0cb905290ad.lhr.life/.well-known/x402.json) | [OpenAPI](https://83823d3c84c70c.lhr.life/openapi.yaml) | [GitHub](https://github.com/TonyGlezx/crawlier-studio))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Add Crawlier Studio as a Production Implementation on x402.

**What it is:** Crawlier Studio exposes image and voice AI generation as pay-per-call x402 endpoints on Base mainnet. Same backend that powers the public Crawlier Studio API (image-01, image-02 at 512/1024/2048; speech-02-turbo TTS).

**Pricing (USDC on Base):**
- image_512: $0.49
- image_1024: $0.79
- image_2048: $1.29
- image_512_v2: $0.69
- tts_1k_chars: $0.05

**x402 conformance:** Standard x402Version 2 manifest at /.well-known/x402.json, accepts.scheme=exact, network=base, asset=USDC (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913), payTo=0xf9fc7B47992e1fE0920f85b2DFb235D7D680a018. Backed by MiniMax inference resold at 90%+ margin.

**AI-agent discovery standards:** ships llms.txt, agents.json, openapi.yaml alongside x402.json. Free /trial endpoint so agents can verify before paying.

**Why Production Implementations:** Same backend has been live for multiple epochs serving real image and TTS requests; payment rails are real Base USDC (chainId 8453); on-chain settlement verifiable via base.blockscout.com.

Links:
- Endpoint: https://48e0cb905290ad.lhr.life
- x402.json: https://48e0cb905290ad.lhr.life/.well-known/x402.json
- llms.txt: https://48e0cb905290ad.lhr.life/llms.txt
- agents.json: https://48e0cb905290ad.lhr.life/agents.json
- OpenAPI: https://48e0cb905290ad.lhr.life/openapi.yaml
- Free trial: https://48e0cb905290ad.lhr.life/trial
- Source: https://github.com/TonyGlezx/crawlier-studio