### PR TITLE
Add Musicwire (paid MusicXML validation + MuseScore rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [Musicwire](https://musicwire.5432wire.com/) - Pay-per-call MusicXML validation, MuseScore rendering, and automated QC for AI agents. $0.10 validate, $0.25/$0.50 render via x402 Exact USDC on Base mainnet; payment is captured only after QC passes. ([Discovery](https://musicwire.5432wire.com/.well-known/x402) | [Docs](https://musicwire.5432wire.com/docs) | [GitHub](https://github.com/thatdudealso/musicwire))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Adds Musicwire to Production Implementations.

- Live x402 service: https://musicwire.5432wire.com/ (docs at /docs, discovery at /.well-known/x402)
- Pay-per-call MusicXML validation ($0.10), MuseScore rendering ($0.25 one part / $0.50 multi-part), automated QC; payment is captured only after QC passes
- x402 Exact USDC on Base mainnet via the CDP facilitator; settled production transaction: 0x1df77f5748fc3b0ebed13bed14069dfc17ed349a670cf00216766597fffbbf84
- Listed in the CDP x402 Bazaar discovery catalog

One line added at the bottom of the category, following the existing format. Links verified.
