### PR TITLE
Add qWICKpay — free multi-EVM x402 facilitator (incl. PulseChain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ Payment verification and settlement services.
 - [Primer](https://x402.primer.systems) - Free x402 facilitator supporting Base and SKALE Base networks, with full ERC-20 support. v1 and v2 x402 both accepted. Batch settlement enabled. [Documentation](https://docs.primer.systems).
 - [Solvador](https://solvador.com) - Multi-network, multi-scheme x402 facilitator: 10 EVM chains (Base, Arbitrum, Optimism, Polygon, Avalanche, Celo, Linea, Unichain, World Chain, Monad) plus Solana and NEAR mainnet. Supports `exact`, `upto` (Permit2), and `batch-settlement` schemes. Settled-transaction dashboard with API keys. [Supported networks & schemes](https://api.solvador.com/supported) · [Blog](https://blog.solvador.com)
 - [NEAR x402 Facilitator](https://x402.mikedotexe.com/) - Open-source, API-key-gated facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery.
+- [qWICKpay](https://pay.wick.pics) - Free public multi-EVM facilitator: `exact` (EIP-3009) plus `upto`/Permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain — the only facilitator on this list covering PulseChain. No account, no API keys. [Supported networks](https://402.wick.pics/supported).
 
 ### Self-Hosted Facilitators
 

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ Payment verification and settlement services.
 - [Primer](https://x402.primer.systems) - Free x402 facilitator supporting Base and SKALE Base networks, with full ERC-20 support. v1 and v2 x402 both accepted. Batch settlement enabled. [Documentation](https://docs.primer.systems).
 - [Solvador](https://solvador.com) - Multi-network, multi-scheme x402 facilitator: 10 EVM chains (Base, Arbitrum, Optimism, Polygon, Avalanche, Celo, Linea, Unichain, World Chain, Monad) plus Solana and NEAR mainnet. Supports `exact`, `upto` (Permit2), and `batch-settlement` schemes. Settled-transaction dashboard with API keys. [Supported networks & schemes](https://api.solvador.com/supported) · [Blog](https://blog.solvador.com)
 - [NEAR x402 Facilitator](https://x402.mikedotexe.com/) - Open-source, API-key-gated facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery.
-- [qWICKpay](https://pay.wick.pics) - Free public multi-EVM facilitator: `exact` (EIP-3009) plus `upto`/Permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain — the only facilitator on this list covering PulseChain. No account, no API keys. [Supported networks](https://402.wick.pics/supported).
+- [qWICKpay](https://pay.wick.pics) - Multi-EVM facilitator: `exact` (EIP-3009) plus `upto`/Permit2 on Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain — the only facilitator on this list covering PulseChain. Flat per-settlement merchant fee (from $0.0009 on Base, first 3 free; [price list](https://pay.wick.pics/about)) — never a percentage, never a payer fee. [Supported networks](https://402.wick.pics/supported).
 
 ### Self-Hosted Facilitators
 


### PR DESCRIPTION
Adds qWICKpay to Hosted Facilitators. Public facilitator: `exact` (EIP-3009) plus `upto`/Permit2 across Ethereum, Base, Arbitrum, Polygon, BNB and PulseChain today — the only entry in the section covering PulseChain — expanding toward all EVM chains. Flat per-settlement merchant fee (public price list https://pay.wick.pics/about — from $0.0009 on Base, first 3 free) — never a percentage, never a payer fee. Live: https://402.wick.pics (`GET /supported`).