### PR TITLE
Add HALOWERK

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Official and community implementations of the x402 protocol.
 
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
+- [HALOWERK](https://halowerk.com) - 100+ pay-per-call POST endpoints for AI agents across web and data extraction, validation, compliance, geospatial and weather data, finance, onchain analysis, media, and developer tools. Payments use x402 v2 with USDC on Base; no accounts or API keys, and settlement happens only after a successful domain response exists. Seventy services are also exposed through an MCP client with per-call and per-session spending limits. ([Catalog](https://halowerk.com/catalog.json) | [llms.txt](https://halowerk.com/llms.txt) | [MCP](https://github.com/halowerk/halowerk-mcp))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
 
 


### PR DESCRIPTION
Adds HALOWERK, a production x402 API suite for AI agents with 100+ paid POST endpoints and an MCP client exposing 70 services. The linked catalog, llms.txt, and MCP repository are public and reachable.