### PR TITLE
Add FixFinderOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Real companies using x402 in production with proven scale and transaction volume
 
 - [Studio X](https://www.studio-x.cc) - Production image and video generation API with 11 models, per-generation x402 pricing, and USDC settlement on Base. ([OpenAPI](https://www.studio-x.cc/openapi.json) | [x402 discovery](https://www.studio-x.cc/.well-known/x402))
 
+- [FixFinderOS](https://fixfinderos.com) - Agent-payable repair and property-maintenance intelligence on Base mainnet. AI agents can purchase maintenance triage for $0.05 USDC via x402, returning trade classification, urgency, safety flags, likely causes, and recommended next actions. ([Agent Discovery](https://fixfinderos.com/.well-known/agent.json))
+
 ### Production Success Metrics
 
 **Key Performance Indicators:**


### PR DESCRIPTION
## Add FixFinderOS

**What:** Adds FixFinderOS, a production x402 service for agent-payable repair and property-maintenance intelligence.

**Why:** FixFinderOS gives AI agents a real Base-mainnet x402 endpoint for maintenance triage, including trade classification, urgency, safety risks, likely causes, and recommended next actions.

**Quality Checklist:**
- [x] Actively maintained
- [x] Production x402 service
- [x] Base mainnet / USDC
- [x] Public agent discovery manifest
- [x] Links are publicly accessible
- [x] End-to-end payment settlement has been verified

**Category:** Production Implementations