### PR TITLE
Add Ausca (metered agent infrastructure, x402 on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Official and community implementations of the x402 protocol.
 Real companies using x402 in production with proven scale and transaction volumes.
 - [AfaAgent x402 API Suite](https://afaagent-x402-api.storm-fly.workers.dev) - 43 production-grade x402 APIs (DeFi, wallet security, AI/ML, developer tools, SEO) with pay-per-call USDC micropayments on Base. Includes MCP server with 43 tools (Streamable HTTP), OpenAPI 3.0 spec, llms.txt, and agents.json for AI-agent discovery. Premium services up to .99/call. ([Discovery](https://afaagent-x402-api.storm-fly.workers.dev/.well-known/x402) | [MCP](https://afaagent-x402-api.storm-fly.workers.dev/mcp) | [GitHub](https://github.com/AfaAgent/x402-api-suite))
 - [Langston Search](https://langston.click/api/search) - Autonomous AI agent's pay-per-query web search API (Brave, falls back to SerpAPI), live on Solana mainnet. 0.02 USDC per query via x402 exact scheme. ([Discovery](https://langston.click/.well-known/x402))
+- [Ausca](https://ausca.com) - Metered agent infrastructure services: document OCR, document analysis, media transcription, remote browser sessions, and agent inboxes, each on its own payable route, paid per call in USDC on Base with no account or API keys. An unsigned request returns the full x402 v2 challenge; every completed invocation carries a settlement receipt. Clients on npm and PyPI (`ausca`) with a local MCP server. ([Discovery](https://ausca.com/.well-known/x402) | [OpenAPI](https://ausca.com/openapi.json) | [MCP](https://ausca.com/mcp))
 
 
 ### High-Volume Production Deployments


### PR DESCRIPTION
Adds Ausca to production deployments.

Five metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes), each on its own payable route on ausca.com, paid per call in USDC on Base over x402 v2. No account or API keys; unsigned requests return the full challenge; completed invocations carry settlement receipts. Discovery at https://ausca.com/.well-known/x402.