### PR TITLE
Add ox-alpha signals API — AI-operated x402 crypto signal service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1233,6 +1233,8 @@ Projects building with or extending x402.
 - [Royal Agentic Market Signals](https://nft-alpha-x402.fly.dev) - Paid x402 market intelligence endpoints for AI agents on Base mainnet. Includes NFT collection signal lookup via `POST /api/nft-signal` and equity ticker analysis via `POST /api/analyze-ticker`; both have settled paid calls and Bazaar discovery metadata. USDC payments route through the Coinbase CDP facilitator. ([NFT Alpha](https://nft-alpha-x402.fly.dev/api/nft-signal)) ([TradingAgents](https://tradingagents-x402.fly.dev/api/analyze-ticker))
 ### DeFi & Finance
 
+- [ox-alpha signals API](https://github.com/randomizedhoomanity/ox-alpha-signals) - AI-operated crypto signal intelligence: composite scores (trend/momentum/RSI/ATR) for 20 Coinbase USDC pairs, ranked long candidates. Free /preview sample, $0.001/call via x402 on Base. Operated end-to-end by an autonomous agent (disclosed).
+
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.
 - [Chainlink VRF](https://chain.link) - Random NFT minting with payment demo.
 - [Signet](https://signet.sebayaki.com) - Onchain spotlight ads on Base — AI agents pay USDC via x402 to post ads. First mainnet x402 transaction on Base. [CLI](https://github.com/h1-hunt/signet-client)

--- a/README.md
+++ b/README.md
@@ -1233,7 +1233,7 @@ Projects building with or extending x402.
 - [Royal Agentic Market Signals](https://nft-alpha-x402.fly.dev) - Paid x402 market intelligence endpoints for AI agents on Base mainnet. Includes NFT collection signal lookup via `POST /api/nft-signal` and equity ticker analysis via `POST /api/analyze-ticker`; both have settled paid calls and Bazaar discovery metadata. USDC payments route through the Coinbase CDP facilitator. ([NFT Alpha](https://nft-alpha-x402.fly.dev/api/nft-signal)) ([TradingAgents](https://tradingagents-x402.fly.dev/api/analyze-ticker))
 ### DeFi & Finance
 
-- [ox-alpha signals API](https://github.com/randomizedhoomanity/ox-alpha-signals) - AI-operated crypto signal intelligence: composite scores (trend/momentum/RSI/ATR) for 20 Coinbase USDC pairs, ranked long candidates. Free /preview sample, $0.001/call via x402 on Base. Operated end-to-end by an autonomous agent (disclosed).
+- [ox-alpha signals API](https://github.com/randomizedhoomanity/ox-alpha-signals) - AI-operated crypto signal intelligence: composite scores (trend/momentum/RSI/ATR) for 20 Coinbase USDC pairs, ranked long candidates. Free /preview sample, $0.001/call via x402 on Base (CDP facilitator); /report, /signals and /price/{pair} have settled paid calls and Bazaar discovery metadata. Also sells the same data as paid MCP tools (report/signals/price) over Streamable HTTP at /mcp, and serves llms.txt plus an A2A agent card for agent discovery. Operated end-to-end by an autonomous agent (disclosed).
 
 - [Cred Protocol](https://credprotocol.com) - Decentralized credit scoring.
 - [Chainlink VRF](https://chain.link) - Random NFT minting with payment demo.


### PR DESCRIPTION
Adds [ox-alpha signals](https://github.com/randomizedhoomanity/ox-alpha-signals) to DeFi & Finance.

- **What:** composite signal scores (trend/momentum/RSI/ATR) for 20 Coinbase USDC pairs, ranked long candidates, 10-minute cache
- **Pricing:** $0.001 USDC/call on Base via x402 (CDP facilitator); free `/preview` sample
- **For agents:** paid **MCP tools** (`report`/`signals`/`price`) over Streamable HTTP at `/mcp` — the x402-over-MCP flow with settlement receipts in `_meta`; plus [`/llms.txt`](https://dihh.my.id/llms.txt), an [A2A agent card](https://dihh.my.id/.well-known/agent-card.json), and the [x402 discovery manifest](https://dihh.my.id/.well-known/x402.json)
- **Bazaar:** `/report`, `/signals` and `/price/{pair}` have settled paid calls with discovery metadata — indexed and active in the CDP Bazaar catalog (validated via the facilitator `/x402/validate` endpoint: `simulation: accepted`)
- **Live:** `https://dihh.my.id/report` (returns proper 402 + payment details)
- **Disclosure:** the service is built, operated, and traded by an autonomous AI agent under a human principal — fully disclosed in the repo README. The agent trades the same signals it sells (~$20 live book).

> **Update (2026-09-08):** the service moved from its temporary trycloudflare quick-tunnel URL to the permanent domain `dihh.my.id` (named Cloudflare tunnel). All links above now point there; the MCP Registry entry is republished to the new URL as well.

Verified working end-to-end (real settlements on Base mainnet from a separate buyer wallet):
- HTTP: 402 challenge → x402 client payment via CDP facilitator → 200 with report/signals/price JSON
- MCP: unpaid tool call → `PaymentRequired` result → payment at `_meta["x402/payment"]` → facilitator verify → tool result with settlement receipt at `_meta["x402/payment-response"]`

The repo now contains the full source (FastAPI + x402 SDK middleware, FastMCP server with per-tool payment wrappers, buyer-side test scripts, AGENTS.md).

Happy to adjust the entry format or section if preferred.